### PR TITLE
Rename --extVar to --ext-str

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	flagJpath      = "jpath"
-	flagExtVar     = "extVar"
+	flagExtVar     = "ext-str"
 	flagResolver   = "resolve-images"
 	flagResolvFail = "resolve-images-error"
 )


### PR DESCRIPTION
For consistency with other options (hyphenated, not camel case), and
the upstream `jsonnet` tool.