### PR TITLE
Fix goreportcard-reported lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # kubecfg
 
 [![Build Status](https://travis-ci.org/ksonnet/kubecfg.svg?branch=master)](https://travis-ci.org/ksonnet/kubecfg)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ksonnet/kubecfg)](https://goreportcard.com/report/github.com/ksonnet/kubecfg)
 
 A tool for managing Kubernetes resources as code.
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -44,6 +44,9 @@ var deleteCmd = &cobra.Command{
 		}
 
 		defaultNs, _, err := clientConfig.Namespace()
+		if err != nil {
+			return err
+		}
 
 		sort.Sort(sort.Reverse(utils.DependencyOrder(objs)))
 

--- a/utils/registry_test.go
+++ b/utils/registry_test.go
@@ -57,17 +57,17 @@ func TestParseAuthHeader(t *testing.T) {
 	h.Add("WWW-Authenticate", ``)
 
 	expected := []*authChallenge{
-		&authChallenge{
+		{
 			Scheme: "basic",
 			Params: map[string]string{},
 		},
-		&authChallenge{
+		{
 			Scheme: "basic",
 			Params: map[string]string{
 				"realm": "User Visible Realm",
 			},
 		},
-		&authChallenge{
+		{
 			Scheme: "bearer",
 			Params: map[string]string{
 				"realm":   "https://auth.docker.io/token",


### PR DESCRIPTION
- `gofmt -s utils/registry_test.go`
- Fix missing `if err != nil` check in `cmd/delete.go` (a bug, but not critical)
- Add goreportcard button to README