### PR TITLE
Fix deploy runtime version check harder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ script:
 after_script: set +e
 
 before_deploy:
+  - echo TARGET=$TARGET OS_NAME=$TRAVIS_OS_NAME GO_VERSION=$TRAVIS_GO_VERSION
   - EXE_NAME=kubecfg-$(go env GOOS)-$(go env GOARCH)
   - cp kubecfg $EXE_NAME
   - strip $EXE_NAME && ./$EXE_NAME version
@@ -90,8 +91,7 @@ deploy:
     secure: "T/LpWZSgeqWBgY3mUNeej55n8TbZZM7UgrHl7pej1CE2cs6YGcfyog3peiXvCcVF9NhGsm6eTXZQeFxsuWgMbWYeqlBnMkHNPPqdNpeRFgY0TkFZXHZLexfqTo2MLgrZiJ+bZl8wZnTTXukieGeLE37ugkBJyceLyfqIaxwRlpDzKPn8XtIqOMOwMq0aeUA8wjSSpuWkuwlGWKwJtI48BNExZZ1FRpPHQdAZjX6zEPT2SuRaACZdoX+3k/Fr91H6O9TplE4q5eCpEdd3y7BGGtMm3WA70SxYIZPGzfwaALGja5BapZr9Eui6ppyPGesQ8zV+zNtOsnK5Phj3QUj8M+v4BmJbxbPyhAIWmFiDlutgwZUkXI+R+SXONy1/LTuLLNSJ9WPQsC9gL09FGQmg+X0s7VpJVWxD8FScY0DJ4/bNLgeWnzwT2YTsduDktqevMpetxJWZGVQx3EN595JJKlZGtE8PouzVm7sRQEfe3Jd0XIcPfj5AV5trEBDjgHZSnU4qa9G9RdUZfswVp+R7SEwoTwEIEyOpFAwi9Qg5wkCAZFU2+86LQOLYH0Pm38//RxSXJEF1abkEb0Y/awz6KKlGBK3z1VSXvK3LQ8r9SwF2h15rD74O1mGM8Mjbs+mJXPxKpCq+BslskRYur3F8tRx45pwr8Ly9dppZd2rrswI="
   file: $EXE_NAME
   on:
-    condition: $TARGET = x86_64-linux-musl || $TRAVIS_OS_NAME = osx
-    go: 1.8.x
+    condition: ( $TARGET = x86_64-linux-musl || $TRAVIS_OS_NAME = osx ) && ${TRAVIS_GO_VERSION}.0 =~ ^1\.8\.
     tags: true
   provider: releases
   skip_cleanup: true


### PR DESCRIPTION
Travis' deploy.on golang version check seems to be surprising.  In
particular `deploy.on.go=1.8.x` will *not* match a build performed
with `go=['1.8.x']`.

This change just gives up and uses an explicit bash conditional.
Uglier, but fewer surprises.