### PR TITLE
Make kubecfg diff exit with non-zero code when a diff is found.

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -67,6 +67,7 @@ var diffCmd = &cobra.Command{
 
 		sort.Sort(utils.AlphabeticalOrder(objs))
 
+		differencesFound := false
 		for _, obj := range objs {
 			desc := fmt.Sprintf("%s/%s", obj.GetKind(), fqName(obj))
 			log.Debugf("Fetching ", desc)
@@ -85,9 +86,10 @@ var diffCmd = &cobra.Command{
 			}
 
 			fmt.Fprintln(out, "---")
-			fmt.Fprintf(out, "- live %s\n+ config %s", desc, desc)
+			fmt.Fprintf(out, "- live %s\n+ config %s\n", desc, desc)
 			if liveObj == nil {
 				fmt.Fprintf(out, "%s doesn't exist on server\n", desc)
+				differencesFound = true
 				continue
 			}
 
@@ -98,6 +100,7 @@ var diffCmd = &cobra.Command{
 			diff := gojsondiff.New().CompareObjects(liveObjObject, obj.Object)
 
 			if diff.Modified() {
+				differencesFound = true
 				fcfg := formatter.AsciiFormatterConfig{
 					Coloring: istty(out),
 				}
@@ -112,6 +115,9 @@ var diffCmd = &cobra.Command{
 			}
 		}
 
+		if differencesFound {
+			return fmt.Errorf("Differences found.")
+		}
 		return nil
 	},
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -33,6 +33,8 @@ import (
 
 const flagDiffStrategy = "diff-strategy"
 
+var ErrDiffFound = fmt.Errorf("Differences found.")
+
 func init() {
 	diffCmd.PersistentFlags().String(flagDiffStrategy, "all", "Diff strategy, all or subset.")
 	RootCmd.AddCommand(diffCmd)
@@ -67,7 +69,7 @@ var diffCmd = &cobra.Command{
 
 		sort.Sort(utils.AlphabeticalOrder(objs))
 
-		differencesFound := false
+		diffFound := false
 		for _, obj := range objs {
 			desc := fmt.Sprintf("%s/%s", obj.GetKind(), fqName(obj))
 			log.Debugf("Fetching ", desc)
@@ -89,7 +91,7 @@ var diffCmd = &cobra.Command{
 			fmt.Fprintf(out, "- live %s\n+ config %s\n", desc, desc)
 			if liveObj == nil {
 				fmt.Fprintf(out, "%s doesn't exist on server\n", desc)
-				differencesFound = true
+				diffFound = true
 				continue
 			}
 
@@ -100,7 +102,7 @@ var diffCmd = &cobra.Command{
 			diff := gojsondiff.New().CompareObjects(liveObjObject, obj.Object)
 
 			if diff.Modified() {
-				differencesFound = true
+				diffFound = true
 				fcfg := formatter.AsciiFormatterConfig{
 					Coloring: istty(out),
 				}
@@ -115,8 +117,8 @@ var diffCmd = &cobra.Command{
 			}
 		}
 
-		if differencesFound {
-			return fmt.Errorf("Differences found.")
+		if diffFound {
+			return ErrDiffFound
 		}
 		return nil
 	},

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@
 package main
 
 import (
+	"os"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/ksonnet/kubecfg/cmd"
@@ -32,7 +34,13 @@ func main() {
 		// errors, like invalid command line flags.
 		logFmt := cmd.NewLogFormatter(log.StandardLogger().Out)
 		log.SetFormatter(logFmt)
+		log.Error(err.Error())
 
-		log.Fatal(err.Error())
+		switch err {
+		case cmd.ErrDiffFound:
+			os.Exit(1)
+		default:
+			os.Exit(2)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -38,9 +38,9 @@ func main() {
 
 		switch err {
 		case cmd.ErrDiffFound:
-			os.Exit(1)
+			os.Exit(10)
 		default:
-			os.Exit(2)
+			os.Exit(1)
 		}
 	}
 }


### PR DESCRIPTION
This makes it easier to integrate into scripts that might automatically apply changes, for instance.

Fixes #60