### PR TITLE
Add manifestJson and manifestYaml functions

### DIFF
--- a/lib/kubecfg.libsonnet
+++ b/lib/kubecfg.libsonnet
@@ -13,6 +13,12 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+// NB: libjsonnet native functions can only pass primitive types, so
+// some functions json-encode the arg.  These "*FromJson" functions
+// will be replaced by regular native version when libjsonnet is able
+// to support this.  This file strives to hide this implementation
+// detail.
+
 {
   // parseJson(data): parses the `data` string as a json document, and
   // returns the resulting jsonnet object.
@@ -23,6 +29,21 @@
   // YAML document will still be returned as an array with one
   // element.
   parseYaml:: std.native("parseYaml"),
+
+  // manifestJson(value, indent): convert the jsonnet object `value`
+  // to a string encoded as "pretty" (multi-line) JSON, with each
+  // nesting level indented by `indent` spaces.
+  manifestJson(value, indent=4):: (
+    local f = std.native("manifestJsonFromJson");
+    f(std.toString(value), indent)
+  ),
+
+  // manifestYaml(value): convert the jsonnet object `value` to a
+  // string encoded as a single YAML document.
+  manifestYaml(value):: (
+    local f = std.native("manifestYamlFromJson");
+    f(std.toString(value))
+  ),
 
   // escapeStringRegex(s): Quote the regex metacharacters found in s.
   // The result is a regex that will match the original literal

--- a/lib/kubecfg_test.jsonnet
+++ b/lib/kubecfg_test.jsonnet
@@ -27,16 +27,43 @@ baz: xyzzy
 ");
 assert x == [[3, 4], {foo: "bar", baz: "xyzzy"}] : "got " + x;
 
+local x = kubecfg.manifestJson({foo: "bar", baz: [3, 4]});
+assert x == '{
+    "baz": [
+        3,
+        4
+    ],
+    "foo": "bar"
+}
+' : "got " + x;
+
+local x = kubecfg.manifestJson({foo: "bar", baz: [3, 4]}, indent=2);
+assert x == '{
+  "baz": [
+    3,
+    4
+  ],
+  "foo": "bar"
+}
+' : "got " + x;
+
+local x = kubecfg.manifestYaml({foo: "bar", baz: [3, 4]});
+assert x == "baz:
+- 3
+- 4
+foo: bar
+" : "got " + x;
+
 local i = kubecfg.resolveImage("busybox");
 assert i == "busybox:latest" : "got " + i;
 
 assert kubecfg.regexMatch("o$", "foo");
 
-local r1 = kubecfg.escapeStringRegex("f[o");
-assert r1 == "f\\[o" : "got " + r1;
+local r = kubecfg.escapeStringRegex("f[o");
+assert r == "f\\[o" : "got " + r;
 
-local r2 = kubecfg.regexSubst("e", "tree", "oll");
-assert r2 == "trolloll" : "got " + r2;
+local r = kubecfg.regexSubst("e", "tree", "oll");
+assert r == "trolloll" : "got " + r;
 
 // Kubecfg wants to see something that looks like a k8s object
 {


### PR DESCRIPTION
jsonnet's `std.toString()` returns "compact" JSON.  Sometimes this is
not appropriate, particularly when generating large output that might
need to be viewed/debugged by a human.

This change implements manifestYaml and manifestJson functions, which
generate YAML and "pretty" JSON respectively.

A slight implementation wrinkle is that libjsonnet currently only
supports passing primitive (scalar) types to native functions, so
these arguments need to be JSON-serialised/unserialised across the
native function call boundary.

Fixes #42 