### PR TITLE
Report client-go version in `version` subcommand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,34 @@
 language: go
 
 go:
-  - 1.7.x
   - 1.8.x
+  - 1.7.x
 
 os:
   - linux
-  - osx
+
+env:
+  global:
+    - VERSION="${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID}"
+    - EXTRA_GO_FLAGS_TEST="-race"
 
 # Frequent jsonnet_cgo crashes with xcode7.3 (default)
 osx_image: xcode8.3
 
 matrix:
   include:
-    - env: TARGET=x86_64-linux-musl
-      os: linux
+    - env: TARGET=x86_64-linux-musl EXTRA_GO_FLAGS_TEST=""
       go: 1.8.x
-
-  exclude:
     # cgo requires golang >= 1.8.1 (or other workarounds) on recent
     # osx/xcode - see https://github.com/golang/go/issues/19734
-    - go: 1.7.x
-      os: osx
+    # 'go test' also hangs repeatably on go-1.8.3/MacOS ?
+    - os: osx
+      go: 1.8.x
+  fast_finish: true
+  allow_failures:
+    # Let us know if/when 'go test' works again on MacOS..
+    - os: osx
+      go: 1.8.x
 
 addons:
   apt:
@@ -68,9 +75,9 @@ install:
   - go build -i -ldflags "$GO_LDFLAGS" .
 
 script:
-  - make VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID}
-  - make VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID} test
-  - make VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID} vet
+  - make VERSION="$VERSION" EXTRA_GO_FLAGS="$EXTRA_GO_FLAGS_TEST" test
+  - make vet
+  - rm -f ./kubecfg && make VERSION="$VERSION"
   - >
     ldd ./kubecfg || otool -L ./kubecfg || :
   - ./kubecfg help

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@
 VERSION = dev-$(shell date +%FT%T%z)
 
 GO = go
-GO_FLAGS = -ldflags="-X main.version=$(VERSION) $(GO_LDFLAGS)"
+EXTRA_GO_FLAGS =
+GO_FLAGS = -ldflags="-X main.version=$(VERSION) $(GO_LDFLAGS)" $(EXTRA_GO_FLAGS)
 GOFMT = gofmt
 
 JSONNET_FILES = lib/kubecfg_test.jsonnet examples/guestbook.jsonnet

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 	jsonnet "github.com/strickyak/jsonnet_cgo"
+	"k8s.io/client-go/pkg/version"
 )
 
 func init() {
@@ -36,5 +37,6 @@ var versionCmd = &cobra.Command{
 		out := cmd.OutOrStdout()
 		fmt.Fprintln(out, "kubecfg version:", Version)
 		fmt.Fprintln(out, "jsonnet version:", jsonnet.Version())
+		fmt.Fprintln(out, "client-go version:", version.Get())
 	},
 }


### PR DESCRIPTION
Adds output like:
```
client-go version: v1.6.8-beta.0+$Format:%h$
```

(Apparently `$Format:%h$` is a misplaced feature - and requires us to declare the client-go git sha at link time, which is too awkward for us at this point.  The preceding version text is useful, however.)