### PR TITLE
Move application logic for 'diff', 'delete', 'show', 'validate' from /cmd to /pkg

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -16,15 +16,9 @@
 package cmd
 
 import (
-	"fmt"
-	"sort"
-
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/ksonnet/kubecfg/utils"
+	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
 const (
@@ -44,8 +38,11 @@ var deleteCmd = &cobra.Command{
 	Short: "Delete Kubernetes resources described in local config",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		flags := cmd.Flags()
+		var err error
 
-		gracePeriod, err := flags.GetInt64(flagGracePeriod)
+		c := kubecfg.DeleteCmd{}
+
+		c.GracePeriod, err = flags.GetInt64(flagGracePeriod)
 		if err != nil {
 			return err
 		}
@@ -60,59 +57,21 @@ var deleteCmd = &cobra.Command{
 			return err
 		}
 
-		objs, err := vm.Expand(files)
+		c.Objs, err = vm.Expand(files)
 		if err != nil {
 			return err
 		}
 
-		clientpool, disco, err := restClientPool(cmd)
+		c.ClientPool, c.Discovery, err = restClientPool(cmd)
 		if err != nil {
 			return err
 		}
 
-		defaultNs, _, err := clientConfig.Namespace()
+		c.DefaultNamespace, _, err = clientConfig.Namespace()
 		if err != nil {
 			return err
 		}
 
-		version, err := utils.FetchVersion(disco)
-		if err != nil {
-			return err
-		}
-
-		sort.Sort(sort.Reverse(utils.DependencyOrder(objs)))
-
-		deleteOpts := metav1.DeleteOptions{}
-		if version.Compare(1, 6) < 0 {
-			// 1.5.x option
-			boolFalse := false
-			deleteOpts.OrphanDependents = &boolFalse
-		} else {
-			// 1.6.x option (NB: Background is broken)
-			fg := metav1.DeletePropagationForeground
-			deleteOpts.PropagationPolicy = &fg
-		}
-		if gracePeriod >= 0 {
-			deleteOpts.GracePeriodSeconds = &gracePeriod
-		}
-
-		for _, obj := range objs {
-			desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(disco, obj), utils.FqName(obj))
-			log.Info("Deleting ", desc)
-
-			c, err := utils.ClientForResource(clientpool, disco, obj, defaultNs)
-			if err != nil {
-				return err
-			}
-
-			err = c.Delete(obj.GetName(), &deleteOpts)
-			if err != nil && !errors.IsNotFound(err) {
-				return fmt.Errorf("Error deleting %s: %s", desc, err)
-			}
-
-			log.Debugf("Deleted object: ", obj)
-		}
-
-		return nil
+		return c.Run()
 	},
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -16,8 +16,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
+	"github.com/ksonnet/kubecfg/metadata"
 	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
@@ -47,17 +50,12 @@ var deleteCmd = &cobra.Command{
 			return err
 		}
 
-		files, err := getFiles(cmd, args)
+		c.Environment, c.Files, err = parseEnvCmd(cmd, args)
 		if err != nil {
 			return err
 		}
 
-		vm, err := newExpander(cmd)
-		if err != nil {
-			return err
-		}
-
-		c.Objs, err = vm.Expand(files)
+		c.Expander, err = newExpander(cmd)
 		if err != nil {
 			return err
 		}
@@ -72,6 +70,11 @@ var deleteCmd = &cobra.Command{
 			return err
 		}
 
-		return c.Run()
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		return c.Run(metadata.AbsPath(cwd))
 	},
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -16,24 +16,15 @@
 package cmd
 
 import (
-	"fmt"
-	"io"
 	"os"
-	"sort"
 
-	"github.com/mattn/go-isatty"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/yudai/gojsondiff"
-	"github.com/yudai/gojsondiff/formatter"
-	"k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/ksonnet/kubecfg/utils"
+	"github.com/ksonnet/kubecfg/metadata"
+	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
 const flagDiffStrategy = "diff-strategy"
-
-var ErrDiffFound = fmt.Errorf("Differences found.")
 
 func init() {
 	addJsonnetFlagsToCmd(diffCmd)
@@ -47,92 +38,42 @@ var diffCmd = &cobra.Command{
 	Use:   "diff [<env>|-f <file-or-dir>]",
 	Short: "Display differences between server and local config",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		out := cmd.OutOrStdout()
 		flags := cmd.Flags()
-		diffStrategy, err := flags.GetString(flagDiffStrategy)
+		var err error
+
+		c := kubecfg.DiffCmd{}
+
+		c.DiffStrategy, err = flags.GetString(flagDiffStrategy)
 		if err != nil {
 			return err
 		}
 
-		files, err := getFiles(cmd, args)
+		c.Environment, c.Files, err = parseEnvCmd(cmd, args)
 		if err != nil {
 			return err
 		}
 
-		vm, err := newExpander(cmd)
+		c.Expander, err = newExpander(cmd)
 		if err != nil {
 			return err
 		}
 
-		objs, err := vm.Expand(files)
+		c.ClientPool, c.Discovery, err = restClientPool(cmd)
 		if err != nil {
 			return err
 		}
 
-		clientpool, disco, err := restClientPool(cmd)
+		c.DefaultNamespace, _, err = clientConfig.Namespace()
 		if err != nil {
 			return err
 		}
 
-		defaultNs, _, err := clientConfig.Namespace()
+		cwd, err := os.Getwd()
 		if err != nil {
 			return err
 		}
 
-		sort.Sort(utils.AlphabeticalOrder(objs))
-
-		diffFound := false
-		for _, obj := range objs {
-			desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(disco, obj), utils.FqName(obj))
-			log.Debugf("Fetching ", desc)
-
-			c, err := utils.ClientForResource(clientpool, disco, obj, defaultNs)
-			if err != nil {
-				return err
-			}
-
-			liveObj, err := c.Get(obj.GetName())
-			if err != nil && errors.IsNotFound(err) {
-				log.Debugf("%s doesn't exist on the server", desc)
-				liveObj = nil
-			} else if err != nil {
-				return fmt.Errorf("Error fetching %s: %v", desc, err)
-			}
-
-			fmt.Fprintln(out, "---")
-			fmt.Fprintf(out, "- live %s\n+ config %s\n", desc, desc)
-			if liveObj == nil {
-				fmt.Fprintf(out, "%s doesn't exist on server\n", desc)
-				diffFound = true
-				continue
-			}
-
-			liveObjObject := liveObj.Object
-			if diffStrategy == "subset" {
-				liveObjObject = removeMapFields(obj.Object, liveObjObject)
-			}
-			diff := gojsondiff.New().CompareObjects(liveObjObject, obj.Object)
-
-			if diff.Modified() {
-				diffFound = true
-				fcfg := formatter.AsciiFormatterConfig{
-					Coloring: istty(out),
-				}
-				formatter := formatter.NewAsciiFormatter(liveObjObject, fcfg)
-				text, err := formatter.Format(diff)
-				if err != nil {
-					return err
-				}
-				fmt.Fprintf(out, "%s", text)
-			} else {
-				fmt.Fprintf(out, "%s unchanged\n", desc)
-			}
-		}
-
-		if diffFound {
-			return ErrDiffFound
-		}
-		return nil
+		return c.Run(metadata.AbsPath(cwd), cmd.OutOrStdout())
 	},
 	Long: `Display differences between server and local configuration.
 
@@ -150,48 +91,4 @@ files.`,
   # Show diff between resources described in a YAML file and the cluster
   # referred to by './kubeconfig'.
   ksonnet diff --kubeconfig=./kubeconfig -f ./pod.yaml`,
-}
-
-func removeFields(config, live interface{}) interface{} {
-	switch c := config.(type) {
-	case map[string]interface{}:
-		return removeMapFields(c, live.(map[string]interface{}))
-	case []interface{}:
-		return removeListFields(c, live.([]interface{}))
-	default:
-		return live
-	}
-}
-
-func removeMapFields(config, live map[string]interface{}) map[string]interface{} {
-	result := map[string]interface{}{}
-	for k, v1 := range config {
-		v2, ok := live[k]
-		if !ok {
-			continue
-		}
-		result[k] = removeFields(v1, v2)
-	}
-	return result
-}
-
-func removeListFields(config, live []interface{}) []interface{} {
-	// If live is longer than config, then the extra elements at the end of the
-	// list will be returned as is so they appear in the diff.
-	result := make([]interface{}, 0, len(live))
-	for i, v2 := range live {
-		if len(config) > i {
-			result = append(result, removeFields(config[i], v2))
-		} else {
-			result = append(result, v2)
-		}
-	}
-	return result
-}
-
-func istty(w io.Writer) bool {
-	if f, ok := w.(*os.File); ok {
-		return isatty.IsTerminal(f.Fd())
-	}
-	return false
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -16,8 +16,9 @@
 package cmd
 
 import (
-	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 	"github.com/spf13/cobra"
+
+	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
 const (

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -16,11 +16,9 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
+	"github.com/ksonnet/kubecfg/pkg/kubecfg"
+	"github.com/ksonnet/kubecfg/template"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -40,64 +38,32 @@ var showCmd = &cobra.Command{
 	Short: "Show expanded resource definitions",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		flags := cmd.Flags()
-		out := cmd.OutOrStdout()
+		var err error
 
-		files, err := getFiles(cmd, args)
+		c := kubecfg.ShowCmd{}
+
+		var files []string
+		files, err = getFiles(cmd, args)
 		if err != nil {
 			return err
 		}
 
-		vm, err := newExpander(cmd)
+		var vm *template.Expander
+		vm, err = newExpander(cmd)
 		if err != nil {
 			return err
 		}
 
-		objs, err := vm.Expand(files)
+		c.Objs, err = vm.Expand(files)
 		if err != nil {
 			return err
 		}
 
-		format, err := flags.GetString(flagFormat)
+		c.Format, err = flags.GetString(flagFormat)
 		if err != nil {
 			return err
 		}
-		switch format {
-		case "yaml":
-			for _, obj := range objs {
-				fmt.Fprintln(out, "---")
-				// Urgh.  Go via json because we need
-				// to trigger the custom scheme
-				// encoding.
-				buf, err := json.Marshal(obj)
-				if err != nil {
-					return err
-				}
-				o := map[string]interface{}{}
-				if err := json.Unmarshal(buf, &o); err != nil {
-					return err
-				}
-				buf, err = yaml.Marshal(o)
-				if err != nil {
-					return err
-				}
-				out.Write(buf)
-			}
-		case "json":
-			enc := json.NewEncoder(out)
-			enc.SetIndent("", "  ")
-			for _, obj := range objs {
-				// TODO: this is not valid framing for JSON
-				if len(objs) > 1 {
-					fmt.Fprintln(out, "---")
-				}
-				if err := enc.Encode(obj); err != nil {
-					return err
-				}
-			}
-		default:
-			return fmt.Errorf("Unknown --format: %s", format)
-		}
 
-		return nil
+		return c.Run(cmd.OutOrStdout())
 	},
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -42,17 +42,12 @@ var showCmd = &cobra.Command{
 
 		c := kubecfg.ShowCmd{}
 
-		files, err := getFiles(cmd, args)
+		c.Environment, c.Files, err = parseEnvCmd(cmd, args)
 		if err != nil {
 			return err
 		}
 
-		vm, err := newExpander(cmd)
-		if err != nil {
-			return err
-		}
-
-		c.Objs, err = vm.Expand(files)
+		c.Expander, err = newExpander(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"github.com/ksonnet/kubecfg/pkg/kubecfg"
-	"github.com/ksonnet/kubecfg/template"
 	"github.com/spf13/cobra"
 )
 
@@ -42,14 +41,12 @@ var showCmd = &cobra.Command{
 
 		c := kubecfg.ShowCmd{}
 
-		var files []string
-		files, err = getFiles(cmd, args)
+		files, err := getFiles(cmd, args)
 		if err != nil {
 			return err
 		}
 
-		var vm *template.Expander
-		vm, err = newExpander(cmd)
+		vm, err := newExpander(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -16,12 +16,9 @@
 package cmd
 
 import (
-	"fmt"
-
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/ksonnet/kubecfg/utils"
+	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
 func init() {
@@ -35,6 +32,10 @@ var validateCmd = &cobra.Command{
 	Use:   "validate [<env>|-f <file-or-dir>]",
 	Short: "Compare generated manifest against server OpenAPI spec",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+
+		c := kubecfg.ValidateCmd{}
+
 		files, err := getFiles(cmd, args)
 		if err != nil {
 			return err
@@ -45,43 +46,17 @@ var validateCmd = &cobra.Command{
 			return err
 		}
 
-		objs, err := vm.Expand(files)
+		c.Objs, err = vm.Expand(files)
 		if err != nil {
 			return err
 		}
 
-		_, disco, err := restClientPool(cmd)
+		_, c.Disco, err = restClientPool(cmd)
 		if err != nil {
 			return err
 		}
 
-		hasError := false
-
-		for _, obj := range objs {
-			desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(disco, obj), utils.FqName(obj))
-			log.Info("Validating ", desc)
-
-			var allErrs []error
-
-			schema, err := utils.NewSwaggerSchemaFor(disco, obj.GroupVersionKind().GroupVersion())
-			if err != nil {
-				allErrs = append(allErrs, fmt.Errorf("Unable to fetch schema: %v", err))
-			} else {
-				// Validate obj
-				allErrs = append(allErrs, schema.Validate(obj)...)
-			}
-
-			for _, err := range allErrs {
-				log.Errorf("Error in %s: %v", desc, err)
-				hasError = true
-			}
-		}
-
-		if hasError {
-			return fmt.Errorf("Validation failed")
-		}
-
-		return nil
+		return c.Run()
 	},
 	Long: `Validate that an application or file is compliant with the Kubernetes
 specification.

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -51,7 +51,7 @@ var validateCmd = &cobra.Command{
 			return err
 		}
 
-		_, c.Disco, err = restClientPool(cmd)
+		_, c.Discovery, err = restClientPool(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -36,17 +36,12 @@ var validateCmd = &cobra.Command{
 
 		c := kubecfg.ValidateCmd{}
 
-		files, err := getFiles(cmd, args)
+		c.Environment, c.Files, err = parseEnvCmd(cmd, args)
 		if err != nil {
 			return err
 		}
 
-		vm, err := newExpander(cmd)
-		if err != nil {
-			return err
-		}
-
-		c.Objs, err = vm.Expand(files)
+		c.Expander, err = newExpander(cmd)
 		if err != nil {
 			return err
 		}
@@ -56,7 +51,7 @@ var validateCmd = &cobra.Command{
 			return err
 		}
 
-		return c.Run()
+		return c.Run(cmd.OutOrStdout())
 	},
 	Long: `Validate that an application or file is compliant with the Kubernetes
 specification.

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/ksonnet/kubecfg/cmd"
+	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
 // Version is overridden using `-X main.version` during release builds
@@ -37,7 +38,7 @@ func main() {
 		log.Error(err.Error())
 
 		switch err {
-		case cmd.ErrDiffFound:
+		case kubecfg.ErrDiffFound:
 			os.Exit(10)
 		default:
 			os.Exit(1)

--- a/pkg/kubecfg/delete.go
+++ b/pkg/kubecfg/delete.go
@@ -1,3 +1,18 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
 package kubecfg
 
 import (
@@ -7,30 +22,39 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 
+	"github.com/ksonnet/kubecfg/metadata"
+	"github.com/ksonnet/kubecfg/template"
 	"github.com/ksonnet/kubecfg/utils"
 )
 
+// DeleteCmd represents the delete subcommand
 type DeleteCmd struct {
 	ClientPool       dynamic.ClientPool
 	Discovery        discovery.DiscoveryInterface
 	DefaultNamespace string
 
-	GracePeriod int64
+	Expander    *template.Expander
+	Environment *string
+	Files       []string
 
-	Objs []*unstructured.Unstructured
+	GracePeriod int64
 }
 
-func (c DeleteCmd) Run() error {
+func (c DeleteCmd) Run(wd metadata.AbsPath) error {
 	version, err := utils.FetchVersion(c.Discovery)
 	if err != nil {
 		return err
 	}
 
-	sort.Sort(sort.Reverse(utils.DependencyOrder(c.Objs)))
+	objs, err := c.Expander.Expand(c.Files)
+	if err != nil {
+		return err
+	}
+
+	sort.Sort(sort.Reverse(utils.DependencyOrder(objs)))
 
 	deleteOpts := metav1.DeleteOptions{}
 	if version.Compare(1, 6) < 0 {
@@ -46,7 +70,7 @@ func (c DeleteCmd) Run() error {
 		deleteOpts.GracePeriodSeconds = &c.GracePeriod
 	}
 
-	for _, obj := range c.Objs {
+	for _, obj := range objs {
 		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
 		log.Info("Deleting ", desc)
 

--- a/pkg/kubecfg/delete.go
+++ b/pkg/kubecfg/delete.go
@@ -1,0 +1,67 @@
+package kubecfg
+
+import (
+	"fmt"
+	"sort"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/ksonnet/kubecfg/utils"
+)
+
+type DeleteCmd struct {
+	ClientPool       dynamic.ClientPool
+	Discovery        discovery.DiscoveryInterface
+	DefaultNamespace string
+
+	GracePeriod int64
+
+	Objs []*unstructured.Unstructured
+}
+
+func (c DeleteCmd) Run() error {
+	version, err := utils.FetchVersion(c.Discovery)
+	if err != nil {
+		return err
+	}
+
+	sort.Sort(sort.Reverse(utils.DependencyOrder(c.Objs)))
+
+	deleteOpts := metav1.DeleteOptions{}
+	if version.Compare(1, 6) < 0 {
+		// 1.5.x option
+		boolFalse := false
+		deleteOpts.OrphanDependents = &boolFalse
+	} else {
+		// 1.6.x option (NB: Background is broken)
+		fg := metav1.DeletePropagationForeground
+		deleteOpts.PropagationPolicy = &fg
+	}
+	if c.GracePeriod >= 0 {
+		deleteOpts.GracePeriodSeconds = &c.GracePeriod
+	}
+
+	for _, obj := range c.Objs {
+		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
+		log.Info("Deleting ", desc)
+
+		client, err := utils.ClientForResource(c.ClientPool, c.Discovery, obj, c.DefaultNamespace)
+		if err != nil {
+			return err
+		}
+
+		err = client.Delete(obj.GetName(), &deleteOpts)
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("Error deleting %s: %s", desc, err)
+		}
+
+		log.Debugf("Deleted object: ", obj)
+	}
+
+	return nil
+}

--- a/pkg/kubecfg/diff.go
+++ b/pkg/kubecfg/diff.go
@@ -1,0 +1,161 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package kubecfg
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	isatty "github.com/mattn/go-isatty"
+	log "github.com/sirupsen/logrus"
+	"github.com/yudai/gojsondiff"
+	"github.com/yudai/gojsondiff/formatter"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/ksonnet/kubecfg/metadata"
+	"github.com/ksonnet/kubecfg/template"
+	"github.com/ksonnet/kubecfg/utils"
+)
+
+var ErrDiffFound = fmt.Errorf("Differences found.")
+
+// DiffCmd represents the diff subcommand
+type DiffCmd struct {
+	ClientPool       dynamic.ClientPool
+	Discovery        discovery.DiscoveryInterface
+	DefaultNamespace string
+
+	Expander    *template.Expander
+	Environment *string
+	Files       []string
+
+	DiffStrategy string
+}
+
+func (c DiffCmd) Run(wd metadata.AbsPath, out io.Writer) error {
+	files, err := GetFiles(wd, c.Environment, c.Files)
+	if err != nil {
+		return err
+	}
+
+	objs, err := c.Expander.Expand(files)
+	if err != nil {
+		return err
+	}
+
+	sort.Sort(utils.AlphabeticalOrder(objs))
+
+	diffFound := false
+	for _, obj := range objs {
+		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
+		log.Debugf("Fetching ", desc)
+
+		client, err := utils.ClientForResource(c.ClientPool, c.Discovery, obj, c.DefaultNamespace)
+		if err != nil {
+			return err
+		}
+
+		liveObj, err := client.Get(obj.GetName())
+		if err != nil && errors.IsNotFound(err) {
+			log.Debugf("%s doesn't exist on the server", desc)
+			liveObj = nil
+		} else if err != nil {
+			return fmt.Errorf("Error fetching %s: %v", desc, err)
+		}
+
+		fmt.Fprintln(out, "---")
+		fmt.Fprintf(out, "- live %s\n+ config %s\n", desc, desc)
+		if liveObj == nil {
+			fmt.Fprintf(out, "%s doesn't exist on server\n", desc)
+			diffFound = true
+			continue
+		}
+
+		liveObjObject := liveObj.Object
+		if c.DiffStrategy == "subset" {
+			liveObjObject = removeMapFields(obj.Object, liveObjObject)
+		}
+		diff := gojsondiff.New().CompareObjects(liveObjObject, obj.Object)
+
+		if diff.Modified() {
+			diffFound = true
+			fcfg := formatter.AsciiFormatterConfig{
+				Coloring: istty(out),
+			}
+			formatter := formatter.NewAsciiFormatter(liveObjObject, fcfg)
+			text, err := formatter.Format(diff)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "%s", text)
+		} else {
+			fmt.Fprintf(out, "%s unchanged\n", desc)
+		}
+	}
+
+	if diffFound {
+		return ErrDiffFound
+	}
+	return nil
+}
+
+func removeFields(config, live interface{}) interface{} {
+	switch c := config.(type) {
+	case map[string]interface{}:
+		return removeMapFields(c, live.(map[string]interface{}))
+	case []interface{}:
+		return removeListFields(c, live.([]interface{}))
+	default:
+		return live
+	}
+}
+
+func removeMapFields(config, live map[string]interface{}) map[string]interface{} {
+	result := map[string]interface{}{}
+	for k, v1 := range config {
+		v2, ok := live[k]
+		if !ok {
+			continue
+		}
+		result[k] = removeFields(v1, v2)
+	}
+	return result
+}
+
+func removeListFields(config, live []interface{}) []interface{} {
+	// If live is longer than config, then the extra elements at the end of the
+	// list will be returned as is so they appear in the diff.
+	result := make([]interface{}, 0, len(live))
+	for i, v2 := range live {
+		if len(config) > i {
+			result = append(result, removeFields(config[i], v2))
+		} else {
+			result = append(result, v2)
+		}
+	}
+	return result
+}
+
+func istty(w io.Writer) bool {
+	if f, ok := w.(*os.File); ok {
+		return isatty.IsTerminal(f.Fd())
+	}
+	return false
+}

--- a/pkg/kubecfg/diff_test.go
+++ b/pkg/kubecfg/diff_test.go
@@ -13,7 +13,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-package cmd
+package kubecfg
 
 import (
 	"testing"

--- a/pkg/kubecfg/show.go
+++ b/pkg/kubecfg/show.go
@@ -11,7 +11,8 @@ import (
 
 type ShowCmd struct {
 	Format string
-	Objs   []*unstructured.Unstructured
+
+	Objs []*unstructured.Unstructured
 }
 
 func (c ShowCmd) Run(out io.Writer) error {

--- a/pkg/kubecfg/show.go
+++ b/pkg/kubecfg/show.go
@@ -1,0 +1,56 @@
+package kubecfg
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	yaml "gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type ShowCmd struct {
+	Format string
+	Objs   []*unstructured.Unstructured
+}
+
+func (c ShowCmd) Run(out io.Writer) error {
+	switch c.Format {
+	case "yaml":
+		for _, obj := range c.Objs {
+			fmt.Fprintln(out, "---")
+			// Urgh.  Go via json because we need
+			// to trigger the custom scheme
+			// encoding.
+			buf, err := json.Marshal(obj)
+			if err != nil {
+				return err
+			}
+			o := map[string]interface{}{}
+			if err := json.Unmarshal(buf, &o); err != nil {
+				return err
+			}
+			buf, err = yaml.Marshal(o)
+			if err != nil {
+				return err
+			}
+			out.Write(buf)
+		}
+	case "json":
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		for _, obj := range c.Objs {
+			// TODO: this is not valid framing for JSON
+			if len(c.Objs) > 1 {
+				fmt.Fprintln(out, "---")
+			}
+			if err := enc.Encode(obj); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("Unknown --format: %s", c.Format)
+	}
+
+	return nil
+}

--- a/pkg/kubecfg/validate.go
+++ b/pkg/kubecfg/validate.go
@@ -1,0 +1,46 @@
+package kubecfg
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/discovery"
+
+	"github.com/ksonnet/kubecfg/utils"
+)
+
+type ValidateCmd struct {
+	Disco discovery.DiscoveryInterface
+	Objs  []*unstructured.Unstructured
+}
+
+func (c ValidateCmd) Run() error {
+	hasError := false
+
+	for _, obj := range c.Objs {
+		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Disco, obj), utils.FqName(obj))
+		log.Info("Validating ", desc)
+
+		var allErrs []error
+
+		schema, err := utils.NewSwaggerSchemaFor(c.Disco, obj.GroupVersionKind().GroupVersion())
+		if err != nil {
+			allErrs = append(allErrs, fmt.Errorf("Unable to fetch schema: %v", err))
+		} else {
+			// Validate obj
+			allErrs = append(allErrs, schema.Validate(obj)...)
+		}
+
+		for _, err := range allErrs {
+			log.Errorf("Error in %s: %v", desc, err)
+			hasError = true
+		}
+	}
+
+	if hasError {
+		return fmt.Errorf("Validation failed")
+	}
+
+	return nil
+}

--- a/pkg/kubecfg/validate.go
+++ b/pkg/kubecfg/validate.go
@@ -1,25 +1,49 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
 package kubecfg
 
 import (
 	"fmt"
+	"io"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/discovery"
 
+	"github.com/ksonnet/kubecfg/template"
 	"github.com/ksonnet/kubecfg/utils"
 )
 
+// ValidateCmd represents the validate subcommand
 type ValidateCmd struct {
 	Discovery discovery.DiscoveryInterface
 
-	Objs []*unstructured.Unstructured
+	Expander    *template.Expander
+	Environment *string
+	Files       []string
 }
 
-func (c ValidateCmd) Run() error {
+func (c ValidateCmd) Run(out io.Writer) error {
 	hasError := false
 
-	for _, obj := range c.Objs {
+	objs, err := c.Expander.Expand(c.Files)
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range objs {
 		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
 		log.Info("Validating ", desc)
 

--- a/pkg/kubecfg/validate.go
+++ b/pkg/kubecfg/validate.go
@@ -11,20 +11,21 @@ import (
 )
 
 type ValidateCmd struct {
-	Disco discovery.DiscoveryInterface
-	Objs  []*unstructured.Unstructured
+	Discovery discovery.DiscoveryInterface
+
+	Objs []*unstructured.Unstructured
 }
 
 func (c ValidateCmd) Run() error {
 	hasError := false
 
 	for _, obj := range c.Objs {
-		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Disco, obj), utils.FqName(obj))
+		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
 		log.Info("Validating ", desc)
 
 		var allErrs []error
 
-		schema, err := utils.NewSwaggerSchemaFor(c.Disco, obj.GroupVersionKind().GroupVersion())
+		schema, err := utils.NewSwaggerSchemaFor(c.Discovery, obj.GroupVersionKind().GroupVersion())
 		if err != nil {
 			allErrs = append(allErrs, fmt.Errorf("Unable to fetch schema: %v", err))
 		} else {

--- a/snippet/parser.go
+++ b/snippet/parser.go
@@ -140,6 +140,10 @@ type Marker interface {
 
 type Markers []Marker
 
+func (ms *Markers) append(m ...Marker) {
+	*ms = append(*ms, m...)
+}
+
 func (ms Markers) String() string {
 	var buf bytes.Buffer
 
@@ -497,7 +501,7 @@ func walkDefaults(markers Markers, placeholderDefaultValues map[int]Markers) {
 }
 
 func (sp *SnippetParser) parse(value string, insertFinalTabstop bool, enforceFinalTabstop bool) Markers {
-	marker := []Marker{}
+	marker := Markers{}
 
 	sp._scanner.text(value)
 	sp._token = sp._scanner.next()
@@ -513,7 +517,7 @@ func (sp *SnippetParser) parse(value string, insertFinalTabstop bool, enforceFin
 	if noFinalTabstop && shouldInsertFinalTabstop {
 		// the snippet uses placeholders but has no
 		// final tabstop defined -> insert at the end
-		marker = append(marker, newPlaceholder(0, Markers{}))
+		marker.append(newPlaceholder(0, Markers{}))
 	}
 
 	return marker
@@ -559,9 +563,9 @@ func (sp *SnippetParser) _parseTM(marker Markers) bool {
 			idOrName := sp._scanner.tokenText(sp._prevToken)
 			if matched, err := regexp.MatchString(`^\d+$`, idOrName); matched && err != nil {
 				i, _ := strconv.Atoi(idOrName)
-				marker = append(marker, newPlaceholder(i, Markers{}))
+				marker.append(newPlaceholder(i, Markers{}))
 			} else {
-				marker = append(marker, newVariable(idOrName, Markers{}))
+				marker.append(newVariable(idOrName, Markers{}))
 			}
 			return true
 
@@ -581,9 +585,9 @@ func (sp *SnippetParser) _parseTM(marker Markers) bool {
 					idOrName := name.String()
 					if match, err := regexp.MatchString(`^\d+$`, idOrName); match && err != nil {
 						i, _ := strconv.Atoi(idOrName)
-						marker = append(marker, newPlaceholder(i, *children))
+						marker.append(newPlaceholder(i, *children))
 					} else {
-						marker = append(marker, newVariable(idOrName, *children))
+						marker.append(newVariable(idOrName, *children))
 					}
 					return true
 				}
@@ -594,17 +598,17 @@ func (sp *SnippetParser) _parseTM(marker Markers) bool {
 
 				// fallback
 				if len(*children) > 0 {
-					marker = append(marker, newText("${"+name.String()+":"))
-					marker = append(marker, *children...)
+					marker.append(newText("${" + name.String() + ":"))
+					marker.append(*children...)
 				} else {
-					marker = append(marker, newText("${"))
-					marker = append(marker, name...)
+					marker.append(newText("${"))
+					marker.append(name...)
 				}
 				return true
 			}
 		}
 
-		marker = append(marker, newText("$"))
+		marker.append(newText("$"))
 		return true
 	}
 	return false
@@ -615,7 +619,7 @@ func (sp *SnippetParser) _parseEscaped(marker Markers) bool {
 		if sp._accept(Dollar) || sp._accept(CurlyClose) || sp._accept(Backslash) {
 			// just consume them
 		}
-		marker = append(marker, newText(sp._scanner.tokenText(sp._prevToken)))
+		marker.append(newText(sp._scanner.tokenText(sp._prevToken)))
 		return true
 	}
 	return false


### PR DESCRIPTION
Similar to @hausdorff's work on refactoring 'update' application logic to pkg/kubecfg/, this change moves the application logic side of the other 4 commands in the PR title from cmd/ to pkg/kubecfg/.