### PR TITLE
Refactor cmd/ application logic to pkg/

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -16,15 +16,9 @@
 package cmd
 
 import (
-	"fmt"
-	"sort"
-
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/ksonnet/kubecfg/utils"
+	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
 const (
@@ -42,75 +36,30 @@ var deleteCmd = &cobra.Command{
 	Short: "Delete Kubernetes resources described in local config",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		flags := cmd.Flags()
+		var err error
 
-		gracePeriod, err := flags.GetInt64(flagGracePeriod)
+		c := kubecfg.DeleteCmd{}
+
+		c.GracePeriod, err = flags.GetInt64(flagGracePeriod)
 		if err != nil {
 			return err
 		}
 
-		files, err := getFiles(cmd, args)
+		c.ClientPool, c.Discovery, err = restClientPool(cmd)
 		if err != nil {
 			return err
 		}
 
-		vm, err := newExpander(cmd)
+		c.DefaultNamespace, _, err = clientConfig.Namespace()
 		if err != nil {
 			return err
 		}
 
-		objs, err := vm.Expand(files)
+		objs, err := readObjs(cmd, args)
 		if err != nil {
 			return err
 		}
 
-		clientpool, disco, err := restClientPool(cmd)
-		if err != nil {
-			return err
-		}
-
-		defaultNs, _, err := clientConfig.Namespace()
-		if err != nil {
-			return err
-		}
-
-		version, err := utils.FetchVersion(disco)
-		if err != nil {
-			return err
-		}
-
-		sort.Sort(sort.Reverse(utils.DependencyOrder(objs)))
-
-		deleteOpts := metav1.DeleteOptions{}
-		if version.Compare(1, 6) < 0 {
-			// 1.5.x option
-			boolFalse := false
-			deleteOpts.OrphanDependents = &boolFalse
-		} else {
-			// 1.6.x option (NB: Background is broken)
-			fg := metav1.DeletePropagationForeground
-			deleteOpts.PropagationPolicy = &fg
-		}
-		if gracePeriod >= 0 {
-			deleteOpts.GracePeriodSeconds = &gracePeriod
-		}
-
-		for _, obj := range objs {
-			desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(disco, obj), utils.FqName(obj))
-			log.Info("Deleting ", desc)
-
-			c, err := utils.ClientForResource(clientpool, disco, obj, defaultNs)
-			if err != nil {
-				return err
-			}
-
-			err = c.Delete(obj.GetName(), &deleteOpts)
-			if err != nil && !errors.IsNotFound(err) {
-				return fmt.Errorf("Error deleting %s: %s", desc, err)
-			}
-
-			log.Debug("Deleted object: ", obj)
-		}
-
-		return nil
+		return c.Run(objs)
 	},
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -16,24 +16,12 @@
 package cmd
 
 import (
-	"fmt"
-	"io"
-	"os"
-	"sort"
-
-	"github.com/mattn/go-isatty"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/yudai/gojsondiff"
-	"github.com/yudai/gojsondiff/formatter"
-	"k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/ksonnet/kubecfg/utils"
+	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
 const flagDiffStrategy = "diff-strategy"
-
-var ErrDiffFound = fmt.Errorf("Differences found.")
 
 func init() {
 	addEnvCmdFlags(diffCmd)
@@ -45,92 +33,32 @@ var diffCmd = &cobra.Command{
 	Use:   "diff [<env>|-f <file-or-dir>]",
 	Short: "Display differences between server and local config",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		out := cmd.OutOrStdout()
 		flags := cmd.Flags()
-		diffStrategy, err := flags.GetString(flagDiffStrategy)
+		var err error
+
+		c := kubecfg.DiffCmd{}
+
+		c.DiffStrategy, err = flags.GetString(flagDiffStrategy)
 		if err != nil {
 			return err
 		}
 
-		files, err := getFiles(cmd, args)
+		c.ClientPool, c.Discovery, err = restClientPool(cmd)
 		if err != nil {
 			return err
 		}
 
-		vm, err := newExpander(cmd)
+		c.DefaultNamespace, _, err = clientConfig.Namespace()
 		if err != nil {
 			return err
 		}
 
-		objs, err := vm.Expand(files)
+		objs, err := readObjs(cmd, args)
 		if err != nil {
 			return err
 		}
 
-		clientpool, disco, err := restClientPool(cmd)
-		if err != nil {
-			return err
-		}
-
-		defaultNs, _, err := clientConfig.Namespace()
-		if err != nil {
-			return err
-		}
-
-		sort.Sort(utils.AlphabeticalOrder(objs))
-
-		diffFound := false
-		for _, obj := range objs {
-			desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(disco, obj), utils.FqName(obj))
-			log.Debug("Fetching ", desc)
-
-			c, err := utils.ClientForResource(clientpool, disco, obj, defaultNs)
-			if err != nil {
-				return err
-			}
-
-			liveObj, err := c.Get(obj.GetName())
-			if err != nil && errors.IsNotFound(err) {
-				log.Debugf("%s doesn't exist on the server", desc)
-				liveObj = nil
-			} else if err != nil {
-				return fmt.Errorf("Error fetching %s: %v", desc, err)
-			}
-
-			fmt.Fprintln(out, "---")
-			fmt.Fprintf(out, "- live %s\n+ config %s\n", desc, desc)
-			if liveObj == nil {
-				fmt.Fprintf(out, "%s doesn't exist on server\n", desc)
-				diffFound = true
-				continue
-			}
-
-			liveObjObject := liveObj.Object
-			if diffStrategy == "subset" {
-				liveObjObject = removeMapFields(obj.Object, liveObjObject)
-			}
-			diff := gojsondiff.New().CompareObjects(liveObjObject, obj.Object)
-
-			if diff.Modified() {
-				diffFound = true
-				fcfg := formatter.AsciiFormatterConfig{
-					Coloring: istty(out),
-				}
-				formatter := formatter.NewAsciiFormatter(liveObjObject, fcfg)
-				text, err := formatter.Format(diff)
-				if err != nil {
-					return err
-				}
-				fmt.Fprintf(out, "%s", text)
-			} else {
-				fmt.Fprintf(out, "%s unchanged\n", desc)
-			}
-		}
-
-		if diffFound {
-			return ErrDiffFound
-		}
-		return nil
+		return c.Run(objs, cmd.OutOrStdout())
 	},
 	Long: `Display differences between server and local configuration.
 
@@ -148,48 +76,4 @@ files.`,
   # Show diff between resources described in a YAML file and the cluster
   # referred to by './kubeconfig'.
   ksonnet diff --kubeconfig=./kubeconfig -f ./pod.yaml`,
-}
-
-func removeFields(config, live interface{}) interface{} {
-	switch c := config.(type) {
-	case map[string]interface{}:
-		return removeMapFields(c, live.(map[string]interface{}))
-	case []interface{}:
-		return removeListFields(c, live.([]interface{}))
-	default:
-		return live
-	}
-}
-
-func removeMapFields(config, live map[string]interface{}) map[string]interface{} {
-	result := map[string]interface{}{}
-	for k, v1 := range config {
-		v2, ok := live[k]
-		if !ok {
-			continue
-		}
-		result[k] = removeFields(v1, v2)
-	}
-	return result
-}
-
-func removeListFields(config, live []interface{}) []interface{} {
-	// If live is longer than config, then the extra elements at the end of the
-	// list will be returned as is so they appear in the diff.
-	result := make([]interface{}, 0, len(live))
-	for i, v2 := range live {
-		if len(config) > i {
-			result = append(result, removeFields(config[i], v2))
-		} else {
-			result = append(result, v2)
-		}
-	}
-	return result
-}
-
-func istty(w io.Writer) bool {
-	if f, ok := w.(*os.File); ok {
-		return isatty.IsTerminal(f.Fd())
-	}
-	return false
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -66,11 +66,6 @@ local configuration. Accepts JSON, YAML, or Jsonnet.`,
 
 		c := kubecfg.UpdateCmd{}
 
-		c.Environment, c.Files, err = parseEnvCmd(cmd, args)
-		if err != nil {
-			return err
-		}
-
 		c.Create, err = flags.GetBool(flagCreate)
 		if err != nil {
 			return err
@@ -101,17 +96,17 @@ local configuration. Accepts JSON, YAML, or Jsonnet.`,
 			return err
 		}
 
-		c.Expander, err = newExpander(cmd)
-		if err != nil {
-			return err
-		}
-
 		cwd, err := os.Getwd()
 		if err != nil {
 			return err
 		}
 
-		return c.Run(metadata.AbsPath(cwd))
+		objs, err := readObjs(cmd, args)
+		if err != nil {
+			return err
+		}
+
+		return c.Run(objs, metadata.AbsPath(cwd))
 	},
 	Long: `Update (or optionally create) Kubernetes resources on the cluster using the
 local configuration. Use the '--create' flag to control whether we create them

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/ksonnet/kubecfg/cmd"
+	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
 // Version is overridden using `-X main.version` during release builds
@@ -37,7 +38,7 @@ func main() {
 		log.Error(err.Error())
 
 		switch err {
-		case cmd.ErrDiffFound:
+		case kubecfg.ErrDiffFound:
 			os.Exit(10)
 		default:
 			os.Exit(1)

--- a/pkg/kubecfg/common.go
+++ b/pkg/kubecfg/common.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ksonnet/kubecfg/metadata"
 )
 
-// TODO: Make this private when we move more commands into `pkg`.
 func GetFiles(wd metadata.AbsPath, env *string, files []string) ([]string, error) {
 	envPresent := env != nil
 	filesPresent := len(files) > 0

--- a/pkg/kubecfg/delete.go
+++ b/pkg/kubecfg/delete.go
@@ -1,0 +1,81 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package kubecfg
+
+import (
+	"fmt"
+	"sort"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/ksonnet/kubecfg/utils"
+)
+
+// DeleteCmd represents the delete subcommand
+type DeleteCmd struct {
+	ClientPool       dynamic.ClientPool
+	Discovery        discovery.DiscoveryInterface
+	DefaultNamespace string
+
+	GracePeriod int64
+}
+
+func (c DeleteCmd) Run(apiObjects []*unstructured.Unstructured) error {
+	version, err := utils.FetchVersion(c.Discovery)
+	if err != nil {
+		return err
+	}
+
+	sort.Sort(sort.Reverse(utils.DependencyOrder(apiObjects)))
+
+	deleteOpts := metav1.DeleteOptions{}
+	if version.Compare(1, 6) < 0 {
+		// 1.5.x option
+		boolFalse := false
+		deleteOpts.OrphanDependents = &boolFalse
+	} else {
+		// 1.6.x option (NB: Background is broken)
+		fg := metav1.DeletePropagationForeground
+		deleteOpts.PropagationPolicy = &fg
+	}
+	if c.GracePeriod >= 0 {
+		deleteOpts.GracePeriodSeconds = &c.GracePeriod
+	}
+
+	for _, obj := range apiObjects {
+		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
+		log.Info("Deleting ", desc)
+
+		client, err := utils.ClientForResource(c.ClientPool, c.Discovery, obj, c.DefaultNamespace)
+		if err != nil {
+			return err
+		}
+
+		err = client.Delete(obj.GetName(), &deleteOpts)
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("Error deleting %s: %s", desc, err)
+		}
+
+		log.Debugf("Deleted object: ", obj)
+	}
+
+	return nil
+}

--- a/pkg/kubecfg/diff.go
+++ b/pkg/kubecfg/diff.go
@@ -1,0 +1,146 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package kubecfg
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	isatty "github.com/mattn/go-isatty"
+	log "github.com/sirupsen/logrus"
+	"github.com/yudai/gojsondiff"
+	"github.com/yudai/gojsondiff/formatter"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/ksonnet/kubecfg/utils"
+)
+
+var ErrDiffFound = fmt.Errorf("Differences found.")
+
+// DiffCmd represents the diff subcommand
+type DiffCmd struct {
+	ClientPool       dynamic.ClientPool
+	Discovery        discovery.DiscoveryInterface
+	DefaultNamespace string
+
+	DiffStrategy string
+}
+
+func (c DiffCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer) error {
+	sort.Sort(utils.AlphabeticalOrder(apiObjects))
+
+	diffFound := false
+	for _, obj := range apiObjects {
+		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
+		log.Debugf("Fetching ", desc)
+
+		client, err := utils.ClientForResource(c.ClientPool, c.Discovery, obj, c.DefaultNamespace)
+		if err != nil {
+			return err
+		}
+
+		liveObj, err := client.Get(obj.GetName())
+		if err != nil && errors.IsNotFound(err) {
+			log.Debugf("%s doesn't exist on the server", desc)
+			liveObj = nil
+		} else if err != nil {
+			return fmt.Errorf("Error fetching %s: %v", desc, err)
+		}
+
+		fmt.Fprintln(out, "---")
+		fmt.Fprintf(out, "- live %s\n+ config %s\n", desc, desc)
+		if liveObj == nil {
+			fmt.Fprintf(out, "%s doesn't exist on server\n", desc)
+			diffFound = true
+			continue
+		}
+
+		liveObjObject := liveObj.Object
+		if c.DiffStrategy == "subset" {
+			liveObjObject = removeMapFields(obj.Object, liveObjObject)
+		}
+		diff := gojsondiff.New().CompareObjects(liveObjObject, obj.Object)
+
+		if diff.Modified() {
+			diffFound = true
+			fcfg := formatter.AsciiFormatterConfig{
+				Coloring: istty(out),
+			}
+			formatter := formatter.NewAsciiFormatter(liveObjObject, fcfg)
+			text, err := formatter.Format(diff)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "%s", text)
+		} else {
+			fmt.Fprintf(out, "%s unchanged\n", desc)
+		}
+	}
+
+	if diffFound {
+		return ErrDiffFound
+	}
+	return nil
+}
+
+func removeFields(config, live interface{}) interface{} {
+	switch c := config.(type) {
+	case map[string]interface{}:
+		return removeMapFields(c, live.(map[string]interface{}))
+	case []interface{}:
+		return removeListFields(c, live.([]interface{}))
+	default:
+		return live
+	}
+}
+
+func removeMapFields(config, live map[string]interface{}) map[string]interface{} {
+	result := map[string]interface{}{}
+	for k, v1 := range config {
+		v2, ok := live[k]
+		if !ok {
+			continue
+		}
+		result[k] = removeFields(v1, v2)
+	}
+	return result
+}
+
+func removeListFields(config, live []interface{}) []interface{} {
+	// If live is longer than config, then the extra elements at the end of the
+	// list will be returned as is so they appear in the diff.
+	result := make([]interface{}, 0, len(live))
+	for i, v2 := range live {
+		if len(config) > i {
+			result = append(result, removeFields(config[i], v2))
+		} else {
+			result = append(result, v2)
+		}
+	}
+	return result
+}
+
+func istty(w io.Writer) bool {
+	if f, ok := w.(*os.File); ok {
+		return isatty.IsTerminal(f.Fd())
+	}
+	return false
+}

--- a/pkg/kubecfg/diff_test.go
+++ b/pkg/kubecfg/diff_test.go
@@ -13,7 +13,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-package cmd
+package kubecfg
 
 import (
 	"testing"

--- a/pkg/kubecfg/show.go
+++ b/pkg/kubecfg/show.go
@@ -1,0 +1,71 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package kubecfg
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	yaml "gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ShowCmd represents the show subcommand
+type ShowCmd struct {
+	Format string
+}
+
+func (c ShowCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer) error {
+	switch c.Format {
+	case "yaml":
+		for _, obj := range apiObjects {
+			fmt.Fprintln(out, "---")
+			// Urgh.  Go via json because we need
+			// to trigger the custom scheme
+			// encoding.
+			buf, err := json.Marshal(obj)
+			if err != nil {
+				return err
+			}
+			o := map[string]interface{}{}
+			if err := json.Unmarshal(buf, &o); err != nil {
+				return err
+			}
+			buf, err = yaml.Marshal(o)
+			if err != nil {
+				return err
+			}
+			out.Write(buf)
+		}
+	case "json":
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		for _, obj := range apiObjects {
+			// TODO: this is not valid framing for JSON
+			if len(apiObjects) > 1 {
+				fmt.Fprintln(out, "---")
+			}
+			if err := enc.Encode(obj); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("Unknown --format: %s", c.Format)
+	}
+
+	return nil
+}

--- a/pkg/kubecfg/validate.go
+++ b/pkg/kubecfg/validate.go
@@ -1,0 +1,62 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package kubecfg
+
+import (
+	"fmt"
+	"io"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/discovery"
+
+	"github.com/ksonnet/kubecfg/utils"
+)
+
+// ValidateCmd represents the validate subcommand
+type ValidateCmd struct {
+	Discovery discovery.DiscoveryInterface
+}
+
+func (c ValidateCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer) error {
+	hasError := false
+
+	for _, obj := range apiObjects {
+		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
+		log.Info("Validating ", desc)
+
+		var allErrs []error
+
+		schema, err := utils.NewSwaggerSchemaFor(c.Discovery, obj.GroupVersionKind().GroupVersion())
+		if err != nil {
+			allErrs = append(allErrs, fmt.Errorf("Unable to fetch schema: %v", err))
+		} else {
+			// Validate obj
+			allErrs = append(allErrs, schema.Validate(obj)...)
+		}
+
+		for _, err := range allErrs {
+			log.Errorf("Error in %s: %v", desc, err)
+			hasError = true
+		}
+	}
+
+	if hasError {
+		return fmt.Errorf("Validation failed")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit will separate the application level logic for the 'show', 'delete',
'validate', and 'diff' commands from the Cobra logic in the cmd/ package.
The application level logic will be placed in pkg/kubecfg/.