### PR TITLE
fix integration tests

### DIFF
--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -107,6 +107,7 @@ func runKubecfgWith(flags []string, input []runtime.Object) error {
 
 	args := []string{}
 	args = append(args, flags...)
+	args = append(args, "-f")
 	args = append(args, fname)
 
 	fmt.Fprintf(GinkgoWriter, "Running %q %q\n", *kubecfgBin, args)


### PR DESCRIPTION
The integration commit (#90) raced with another (#80) that changes the
`kubecfg` command line.  This commit adds the newly-required `-f` flag.