### PR TITLE
Revert "Remove kubectl and Jsonnet flags from commands that don't use…

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -27,8 +27,6 @@ const (
 
 func init() {
 	RootCmd.AddCommand(deleteCmd)
-	addJsonnetFlagsToCmd(deleteCmd)
-	addKubectlFlagsToCmd(deleteCmd)
 	addEnvCmdFlags(deleteCmd)
 	deleteCmd.PersistentFlags().Int64(flagGracePeriod, -1, "Number of seconds given to resources to terminate gracefully. A negative value is ignored")
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -24,8 +24,6 @@ import (
 const flagDiffStrategy = "diff-strategy"
 
 func init() {
-	addJsonnetFlagsToCmd(diffCmd)
-	addKubectlFlagsToCmd(diffCmd)
 	addEnvCmdFlags(diffCmd)
 	diffCmd.PersistentFlags().String(flagDiffStrategy, "all", "Diff strategy, all or subset.")
 	RootCmd.AddCommand(diffCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,10 +63,27 @@ var clientConfig clientcmd.ClientConfig
 
 func init() {
 	RootCmd.PersistentFlags().CountP(flagVerbose, "v", "Increase verbosity. May be given multiple times.")
+	RootCmd.PersistentFlags().StringSliceP(flagJpath, "J", nil, "Additional jsonnet library search path")
+	RootCmd.PersistentFlags().StringSliceP(flagExtVar, "V", nil, "Values of external variables")
+	RootCmd.PersistentFlags().StringSlice(flagExtVarFile, nil, "Read external variable from a file")
+	RootCmd.PersistentFlags().StringSliceP(flagTlaVar, "A", nil, "Values of top level arguments")
+	RootCmd.PersistentFlags().StringSlice(flagTlaVarFile, nil, "Read top level argument from a file")
+	RootCmd.PersistentFlags().String(flagResolver, "noop", "Change implementation of resolveImage native function. One of: noop, registry")
+	RootCmd.PersistentFlags().String(flagResolvFail, "warn", "Action when resolveImage fails. One of ignore,warn,error")
+
+	// The "usual" clientcmd/kubectl flags
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+	overrides := clientcmd.ConfigOverrides{}
+	kflags := clientcmd.RecommendedConfigOverrideFlags("")
+	RootCmd.PersistentFlags().StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
+	clientcmd.BindOverrideFlags(&overrides, RootCmd.PersistentFlags(), kflags)
+	clientConfig = clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
+
+	RootCmd.PersistentFlags().Set("logtostderr", "true")
 }
 
-// RootCmd is the root of all commands that expand Jsonnet code or talk to
-// the API server
+// RootCmd is the root of cobra subcommand tree
 var RootCmd = &cobra.Command{
 	Use:           "kubecfg",
 	Short:         "Synchronise Kubernetes resources with config files",
@@ -89,29 +106,6 @@ var RootCmd = &cobra.Command{
 
 		return nil
 	},
-}
-
-func addJsonnetFlagsToCmd(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringSliceP(flagJpath, "J", nil, "Additional jsonnet library search path")
-	cmd.PersistentFlags().StringSliceP(flagExtVar, "V", nil, "Values of external variables")
-	cmd.PersistentFlags().StringSlice(flagExtVarFile, nil, "Read external variable from a file")
-	cmd.PersistentFlags().StringSliceP(flagTlaVar, "A", nil, "Values of top level arguments")
-	cmd.PersistentFlags().StringSlice(flagTlaVarFile, nil, "Read top level argument from a file")
-	cmd.PersistentFlags().String(flagResolver, "noop", "Change implementation of resolveImage native function. One of: noop, registry")
-	cmd.PersistentFlags().String(flagResolvFail, "warn", "Action when resolveImage fails. One of ignore,warn,error")
-}
-
-func addKubectlFlagsToCmd(cmd *cobra.Command) {
-	// The "usual" clientcmd/kubectl flags
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	overrides := clientcmd.ConfigOverrides{}
-	kflags := clientcmd.RecommendedConfigOverrideFlags("")
-	cmd.PersistentFlags().StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
-	clientcmd.BindOverrideFlags(&overrides, cmd.PersistentFlags(), kflags)
-	clientConfig = clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
-
-	cmd.PersistentFlags().Set("logtostderr", "true")
 }
 
 func logLevel(verbosity int) log.Level {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -27,8 +27,6 @@ const (
 
 func init() {
 	RootCmd.AddCommand(showCmd)
-	addJsonnetFlagsToCmd(showCmd)
-	addKubectlFlagsToCmd(showCmd)
 	addEnvCmdFlags(showCmd)
 	showCmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format.  Supported values are: json, yaml")
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -49,8 +49,6 @@ const (
 func init() {
 	RootCmd.AddCommand(updateCmd)
 
-	addJsonnetFlagsToCmd(updateCmd)
-	addKubectlFlagsToCmd(updateCmd)
 	addEnvCmdFlags(updateCmd)
 	updateCmd.PersistentFlags().Bool(flagCreate, true, "Create missing resources")
 	updateCmd.PersistentFlags().Bool(flagSkipGc, false, "Don't perform garbage collection, even with --"+flagGcTag)
@@ -59,8 +57,9 @@ func init() {
 }
 
 var updateCmd = &cobra.Command{
-	Use:   "update [<env>|-f <file-or-dir>]",
-	Short: `Update (or optionally create) Kubernetes resources on the cluster using the local configuration. Accepts JSON, YAML, or Jsonnet.`,
+	Use: "update [<env>|-f <file-or-dir>]",
+	Short: `Update (or optionally create) Kubernetes resources on the cluster using the
+local configuration. Accepts JSON, YAML, or Jsonnet.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		flags := cmd.Flags()
 		var err error

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -23,8 +23,6 @@ import (
 
 func init() {
 	RootCmd.AddCommand(validateCmd)
-	addJsonnetFlagsToCmd(validateCmd)
-	addKubectlFlagsToCmd(validateCmd)
 	addEnvCmdFlags(validateCmd)
 }
 


### PR DESCRIPTION
… them"

This reverts commit 020d5da068bc77be60bce0cb722d2aecc2f9321f.

The change broke --namespace (and other flag) handling, because it
recreates the `clientConfig` global singleton multiple times - only
some of which are correctly tied to the relevant flags.

Fixes #103 