### PR TITLE
Change directory structure generated by 'init' to support envs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -311,8 +311,8 @@ func expandEnvCmdObjs(cmd *cobra.Command, args []string) ([]*unstructured.Unstru
 			return nil, err
 		}
 
-		libPath, vendorLibPath := manager.LibPaths()
-		expander.FlagJpath = append([]string{string(libPath), string(vendorLibPath)}, expander.FlagJpath...)
+		libPath, envLibPath := manager.LibPaths(*env)
+		expander.FlagJpath = append([]string{string(libPath), string(envLibPath)}, expander.FlagJpath...)
 
 		fileNames, err = manager.ComponentPaths()
 		if err != nil {

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -20,7 +20,7 @@ type AbsPaths []string
 type Manager interface {
 	Root() AbsPath
 	ComponentPaths() (AbsPaths, error)
-	LibPaths() (libPath, vendorLibPath AbsPath)
+	LibPaths(envName string) (libPath, envLibPath AbsPath)
 	//
 	// TODO: Fill in methods as we need them.
 	//

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -50,14 +50,13 @@ func TestInitSuccess(t *testing.T) {
 		t.Fatalf("Failed to init cluster spec: %v", err)
 	}
 
-	defaultEnvDir := appendToAbsPath(schemaDir, defaultEnvName)
+	defaultEnvDir := appendToAbsPath(environmentsDir, defaultEnvName)
 	paths := []AbsPath{
 		ksonnetDir,
 		libDir,
 		componentsDir,
+		environmentsDir,
 		vendorDir,
-		schemaDir,
-		vendorLibDir,
 		defaultEnvDir,
 	}
 


### PR DESCRIPTION
This commit will remove the vendor/lib and vendor/schema directories
generated by 'init'. An 'environments' directory will be created from
the root app directory, with the default environment directory 'dev'
and it's containing contents rooted at 'environments'.

The intention of environments are to represent the deployment
environments of Kubernete clusters, with the following example
directory structure:

```
app-name/
  ..
  envs/
    dev/
    us-west/
      prod/
      staging/
```