### PR TITLE
Set default permissions in `metadata.Manager` to 0644

### DIFF
--- a/metadata/environment.go
+++ b/metadata/environment.go
@@ -74,26 +74,26 @@ func (m *manager) createEnvironment(name, uri string, extensionsLibData, k8sLibD
 	}
 
 	envPath := appendToAbsPath(m.environmentsPath, name)
-	err = m.appFS.MkdirAll(string(envPath), os.ModePerm)
+	err = m.appFS.MkdirAll(string(envPath), defaultPermissions)
 	if err != nil {
 		return err
 	}
 
 	// Generate the schema file.
 	schemaPath := appendToAbsPath(envPath, schemaFilename)
-	err = afero.WriteFile(m.appFS, string(schemaPath), specData, os.ModePerm)
+	err = afero.WriteFile(m.appFS, string(schemaPath), specData, defaultPermissions)
 	if err != nil {
 		return err
 	}
 
 	k8sLibPath := appendToAbsPath(envPath, k8sLibFilename)
-	err = afero.WriteFile(m.appFS, string(k8sLibPath), k8sLibData, 0644)
+	err = afero.WriteFile(m.appFS, string(k8sLibPath), k8sLibData, defaultPermissions)
 	if err != nil {
 		return err
 	}
 
 	extensionsLibPath := appendToAbsPath(envPath, extensionsLibFilename)
-	err = afero.WriteFile(m.appFS, string(extensionsLibPath), extensionsLibData, 0644)
+	err = afero.WriteFile(m.appFS, string(extensionsLibPath), extensionsLibData, defaultPermissions)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (m *manager) createEnvironment(name, uri string, extensionsLibData, k8sLibD
 	}
 
 	envSpecPath := appendToAbsPath(envPath, specFilename)
-	return afero.WriteFile(m.appFS, string(envSpecPath), envSpecData, os.ModePerm)
+	return afero.WriteFile(m.appFS, string(envSpecPath), envSpecData, defaultPermissions)
 }
 
 func (m *manager) DeleteEnvironment(name string) error {
@@ -240,7 +240,7 @@ func (m *manager) SetEnvironment(name string, desired Environment) error {
 
 		envPath := appendToAbsPath(m.environmentsPath, name)
 		specPath := appendToAbsPath(envPath, specFilename)
-		return afero.WriteFile(m.appFS, string(specPath), newSpec, os.ModePerm)
+		return afero.WriteFile(m.appFS, string(specPath), newSpec, defaultPermissions)
 	}
 
 	return nil

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -16,10 +16,13 @@
 package metadata
 
 import (
+	"os"
+
 	"github.com/spf13/afero"
 )
 
 var appFS afero.Fs
+var defaultPermissions = os.FileMode(0644)
 
 // AbsPath is an advisory type that represents an absolute path. It is advisory
 // in that it is not forced to be absolute, but rather, meant to indicate

--- a/metadata/manager.go
+++ b/metadata/manager.go
@@ -157,7 +157,7 @@ func (m *manager) createAppDirTree() error {
 	}
 
 	for _, p := range paths {
-		if err := m.appFS.MkdirAll(string(p), os.ModePerm); err != nil {
+		if err := m.appFS.MkdirAll(string(p), defaultPermissions); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Currently all files and folders created with the `metadata.Manager`
(which is the core FS management subsystem) are created with permissions
0777, i.e., everyone has all permissions.

This commit transistions us to a more locked down permissions set, 0644,
which allows the user to do everything except execute, and everyone else
to only read.

Since we don't store any app code that needs to be executed, this should
be suitable for everything.

Fixes #136.