### PR TITLE
Add logging to 'env' subcommands

### DIFF
--- a/pkg/kubecfg/env.go
+++ b/pkg/kubecfg/env.go
@@ -21,6 +21,8 @@ import (
 	"sort"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/ksonnet/kubecfg/metadata"
 )
 
@@ -37,6 +39,7 @@ func NewEnvAddCmd(name, uri, specFlag string, rootPath metadata.AbsPath) (*EnvAd
 	if err != nil {
 		return nil, err
 	}
+	log.Debugf("Generating ksonnetLib data with spec: %s", specFlag)
 
 	return &EnvAddCmd{name: name, uri: uri, spec: spec, rootPath: rootPath}, nil
 }


### PR DESCRIPTION
This commit will add logging to all env subcommands 'list', 'set',
'add', and 'rm'. It adds both Info level and Debug level logging.

Fixes #137