### PR TITLE
Set default log level to 'Info'

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,8 +121,6 @@ func defaultNamespace(c clientcmd.ClientConfig) (string, error) {
 func logLevel(verbosity int) log.Level {
 	switch verbosity {
 	case 0:
-		return log.WarnLevel
-	case 1:
 		return log.InfoLevel
 	default:
 		return log.DebugLevel


### PR DESCRIPTION
Currently 'Info' level logs are only shown with the '-v' flag. This
makes commands without the '-v' flag of little use to users, especially
on success cases, due to no output.

This commit will set the default log level to 'Info', and passing a '-v'
flag will log at a 'Debug' level.