### PR TITLE
Fix improper elision of -J flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -357,7 +357,7 @@ func expandEnvCmdObjs(cmd *cobra.Command, envSpec *envSpec, cwd metadata.AbsPath
 	}
 
 	fileNames := envSpec.files
-	if envPresent && !filesPresent {
+	if envPresent {
 		manager, err := metadata.Find(cwd)
 		if err != nil {
 			return nil, err
@@ -366,10 +366,13 @@ func expandEnvCmdObjs(cmd *cobra.Command, envSpec *envSpec, cwd metadata.AbsPath
 		libPath, envLibPath := manager.LibPaths(*envSpec.env)
 		expander.FlagJpath = append([]string{string(libPath), string(envLibPath)}, expander.FlagJpath...)
 
-		fileNames, err = manager.ComponentPaths()
-		if err != nil {
-			return nil, err
+		if !filesPresent {
+			fileNames, err = manager.ComponentPaths()
+			if err != nil {
+				return nil, err
+			}
 		}
+
 	}
 
 	//


### PR DESCRIPTION
Currently if we use a command like `apply default -f
components/whatever.yaml`, kubecfg will fail to emit flags that add
ksonnet-lib to the -J paths. This means that, while a command like
`apply default` will correctly linke against (e.g.) `k.libsonnet`,
adding the `-f` flag will not.

This commit will correct this problem for all commands of this form.