### PR TITLE
Remove client-go flags from commands that don't use

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -50,6 +50,8 @@ func init() {
 	RootCmd.AddCommand(applyCmd)
 
 	addEnvCmdFlags(applyCmd)
+	bindClientGoFlags(applyCmd)
+	bindJsonnetFlags(applyCmd)
 	applyCmd.PersistentFlags().Bool(flagCreate, true, "Create missing resources")
 	applyCmd.PersistentFlags().Bool(flagSkipGc, false, "Don't perform garbage collection, even with --"+flagGcTag)
 	applyCmd.PersistentFlags().String(flagGcTag, "", "Add this tag to updated objects, and garbage collect existing objects with this tag and not in config")

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -31,6 +31,8 @@ const (
 func init() {
 	RootCmd.AddCommand(deleteCmd)
 	addEnvCmdFlags(deleteCmd)
+	bindClientGoFlags(deleteCmd)
+	bindJsonnetFlags(deleteCmd)
 	deleteCmd.PersistentFlags().Int64(flagGracePeriod, -1, "Number of seconds given to resources to terminate gracefully. A negative value is ignored")
 }
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -28,6 +28,8 @@ const flagDiffStrategy = "diff-strategy"
 
 func init() {
 	addEnvCmdFlags(diffCmd)
+	bindClientGoFlags(diffCmd)
+	bindJsonnetFlags(diffCmd)
 	diffCmd.PersistentFlags().String(flagDiffStrategy, "all", "Diff strategy, all or subset.")
 	RootCmd.AddCommand(diffCmd)
 }

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -32,6 +32,8 @@ const (
 
 func init() {
 	RootCmd.AddCommand(envCmd)
+	bindClientGoFlags(envCmd)
+
 	envCmd.AddCommand(envAddCmd)
 	envCmd.AddCommand(envRmCmd)
 	envCmd.AddCommand(envListCmd)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -32,6 +32,8 @@ func init() {
 	// TODO: We need to make this default to checking the `kubeconfig` file.
 	initCmd.PersistentFlags().String(flagAPISpec, "version:v1.7.0",
 		"Manually specify API version from OpenAPI schema, cluster, or Kubernetes version")
+
+	bindClientGoFlags(initCmd)
 }
 
 var initCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,26 +62,34 @@ const (
 
 var clientConfig clientcmd.ClientConfig
 var overrides clientcmd.ConfigOverrides
+var loadingRules clientcmd.ClientConfigLoadingRules
 
 func init() {
 	RootCmd.PersistentFlags().CountP(flagVerbose, "v", "Increase verbosity. May be given multiple times.")
-	RootCmd.PersistentFlags().StringSliceP(flagJpath, "J", nil, "Additional jsonnet library search path")
-	RootCmd.PersistentFlags().StringSliceP(flagExtVar, "V", nil, "Values of external variables")
-	RootCmd.PersistentFlags().StringSlice(flagExtVarFile, nil, "Read external variable from a file")
-	RootCmd.PersistentFlags().StringSliceP(flagTlaVar, "A", nil, "Values of top level arguments")
-	RootCmd.PersistentFlags().StringSlice(flagTlaVarFile, nil, "Read top level argument from a file")
-	RootCmd.PersistentFlags().String(flagResolver, "noop", "Change implementation of resolveImage native function. One of: noop, registry")
-	RootCmd.PersistentFlags().String(flagResolvFail, "warn", "Action when resolveImage fails. One of ignore,warn,error")
 
 	// The "usual" clientcmd/kubectl flags
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules = *clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	kflags := clientcmd.RecommendedConfigOverrideFlags("")
-	RootCmd.PersistentFlags().StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
-	clientcmd.BindOverrideFlags(&overrides, RootCmd.PersistentFlags(), kflags)
-	clientConfig = clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
+	clientConfig = clientcmd.NewInteractiveDeferredLoadingClientConfig(&loadingRules, &overrides, os.Stdin)
 
 	RootCmd.PersistentFlags().Set("logtostderr", "true")
+}
+
+func bindJsonnetFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringSliceP(flagJpath, "J", nil, "Additional jsonnet library search path")
+	cmd.PersistentFlags().StringSliceP(flagExtVar, "V", nil, "Values of external variables")
+	cmd.PersistentFlags().StringSlice(flagExtVarFile, nil, "Read external variable from a file")
+	cmd.PersistentFlags().StringSliceP(flagTlaVar, "A", nil, "Values of top level arguments")
+	cmd.PersistentFlags().StringSlice(flagTlaVarFile, nil, "Read top level argument from a file")
+	cmd.PersistentFlags().String(flagResolver, "noop", "Change implementation of resolveImage native function. One of: noop, registry")
+	cmd.PersistentFlags().String(flagResolvFail, "warn", "Action when resolveImage fails. One of ignore,warn,error")
+}
+
+func bindClientGoFlags(cmd *cobra.Command) {
+	kflags := clientcmd.RecommendedConfigOverrideFlags("")
+	ep := &loadingRules.ExplicitPath
+	cmd.PersistentFlags().StringVar(ep, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
+	clientcmd.BindOverrideFlags(&overrides, cmd.PersistentFlags(), kflags)
 }
 
 // RootCmd is the root of cobra subcommand tree

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -31,6 +31,7 @@ const (
 func init() {
 	RootCmd.AddCommand(showCmd)
 	addEnvCmdFlags(showCmd)
+	bindJsonnetFlags(showCmd)
 	showCmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format.  Supported values are: json, yaml")
 }
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -28,6 +28,8 @@ func init() {
 	RootCmd.AddCommand(updateCmd)
 
 	addEnvCmdFlags(updateCmd)
+	bindClientGoFlags(updateCmd)
+	bindJsonnetFlags(updateCmd)
 	updateCmd.PersistentFlags().Bool(flagCreate, true, "Create missing resources")
 	updateCmd.PersistentFlags().Bool(flagSkipGc, false, "Don't perform garbage collection, even with --"+flagGcTag)
 	updateCmd.PersistentFlags().String(flagGcTag, "", "Add this tag to updated objects, and garbage collect existing objects with this tag and not in config")

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -27,6 +27,8 @@ import (
 func init() {
 	RootCmd.AddCommand(validateCmd)
 	addEnvCmdFlags(validateCmd)
+	bindJsonnetFlags(validateCmd)
+	bindClientGoFlags(validateCmd)
 }
 
 var validateCmd = &cobra.Command{


### PR DESCRIPTION
DON'T MERGE. This is meant to test whether the client-go flags can be removed from commands that don't use them.