### PR TITLE
Add `prototype list` command

### DIFF
--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -26,6 +26,7 @@ import (
 
 func init() {
 	RootCmd.AddCommand(prototypeCmd)
+	prototypeCmd.AddCommand(prototypeListCmd)
 	prototypeCmd.AddCommand(prototypeDescribeCmd)
 	prototypeCmd.AddCommand(prototypeSearchCmd)
 	prototypeCmd.AddCommand(prototypeUseCmd)
@@ -75,6 +76,29 @@ Commands:
 
   # Search known prototype metadata for the string 'deployment'.
   ksonnet prototype search deployment`,
+}
+
+var prototypeListCmd = &cobra.Command{
+	Use:   "list <name-substring>",
+	Short: `List all known ksonnet prototypes`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("Command 'prototype list' does not take any arguments")
+		}
+
+		index := prototype.NewIndex([]*prototype.SpecificationSchema{})
+		protos, err := index.List()
+		if err != nil {
+			return err
+		} else if len(protos) == 0 {
+			return fmt.Errorf("No prototypes found")
+		}
+
+		fmt.Print(protos)
+
+		return nil
+	},
+	Long: `List all known ksonnet prototypes.`,
 }
 
 var prototypeDescribeCmd = &cobra.Command{

--- a/prototype/index.go
+++ b/prototype/index.go
@@ -13,6 +13,14 @@ type index struct {
 	prototypes map[string]*SpecificationSchema
 }
 
+func (idx *index) List() (SpecificationSchemas, error) {
+	prototypes := []*SpecificationSchema{}
+	for _, prototype := range idx.prototypes {
+		prototypes = append(prototypes, prototype)
+	}
+	return prototypes, nil
+}
+
 func (idx *index) SearchNames(query string, opts SearchOptions) (SpecificationSchemas, error) {
 	// TODO(hausdorff): This is the world's worst search algorithm. Improve it at
 	// some point.

--- a/prototype/interface.go
+++ b/prototype/interface.go
@@ -31,6 +31,7 @@ const (
 
 // Index represents a queryable index of prototype specifications.
 type Index interface {
+	List() (SpecificationSchemas, error)
 	SearchNames(query string, opts SearchOptions) (SpecificationSchemas, error)
 }
 


### PR DESCRIPTION
The `prototype list` command lists all known prototypes. It is
functionally equivalent to a `prototype search` that returns all
prototypes.