### PR TITLE
Construct base components Obj

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,75 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestConstructBaseObj(t *testing.T) {
+	tests := []struct {
+		inputPaths []string
+		expected   string
+	}{
+		// test simple case with 1 .jsonnet path
+		{
+			[]string{
+				"some/fake/path/foo.jsonnet",
+			},
+			`{
+  foo: import "some/fake/path/foo.jsonnet",
+}
+`,
+		},
+		// test multiple .jsonnet path case
+		{
+			[]string{
+				"some/fake/path/foo.jsonnet",
+				"another/fake/path/bar.jsonnet",
+			},
+			`{
+  foo: import "some/fake/path/foo.jsonnet",
+  bar: import "another/fake/path/bar.jsonnet",
+}
+`,
+		},
+		// test zero path case
+		{
+			[]string{},
+			`{
+}
+`,
+		},
+		// test non-jsonnet extension case
+		{
+			[]string{
+				"some/fake/path/foo.libsonnet",
+				"another/fake/path/bar.jsonnet",
+			},
+			`{
+  bar: import "another/fake/path/bar.jsonnet",
+}
+`,
+		},
+	}
+
+	for _, s := range tests {
+		res := constructBaseObj(s.inputPaths)
+		if res != s.expected {
+			t.Errorf("Wrong object constructed\n  expected: %v\n  got: %v", s.expected, res)
+		}
+	}
+}

--- a/lib/kubecfg_test.jsonnet
+++ b/lib/kubecfg_test.jsonnet
@@ -13,7 +13,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-// Run me with `../kubecfg show kubecfg_test.jsonnet`
+// Run me with `../kubecfg show -f kubecfg_test.jsonnet`
 local kubecfg = import "kubecfg.libsonnet";
 
 assert kubecfg.parseJson("[3, 4]") == [3, 4];

--- a/template/expander.go
+++ b/template/expander.go
@@ -20,6 +20,7 @@ type Expander struct {
 	ExtVarFiles []string
 	TlaVars     []string
 	TlaVarFiles []string
+	ExtCodes    []string
 
 	Resolver   string
 	FailAction string
@@ -110,6 +111,21 @@ func (spec *Expander) jsonnetVM() (*jsonnet.VM, error) {
 			return nil, err
 		}
 		vm.TlaVar(kv[0], string(v))
+	}
+
+	for _, extcode := range spec.ExtCodes {
+		kv := strings.SplitN(extcode, "=", 2)
+		switch len(kv) {
+		case 1:
+			v, present := os.LookupEnv(kv[0])
+			if present {
+				vm.ExtCode(kv[0], v)
+			} else {
+				return nil, fmt.Errorf("Missing environment variable: %s", kv[0])
+			}
+		case 2:
+			vm.ExtCode(kv[0], kv[1])
+		}
 	}
 
 	resolver, err := spec.buildResolver()


### PR DESCRIPTION
This implements the `ksonnet.importComponents()` piece specified by the design [here](https://docs.google.com/document/d/1yU6Zi3t1D-sSLnMEE6aQn2NS41tLqiYgzEoZnQvQEbY).

In order to support environment heirarchy, we need to be able to
reference all components. This commit will implement component imports
as k-v pairs ex: foo: "import/foo.jsonnet" in a Jsonnet object. This
jsonnet object will then be assigned using ExtCode so that it can be
referenced by a base.libsonnet file which environments can build /
override on.

See the design doc above for more information.