### PR TITLE
Support `diff`ing between two environments

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -18,8 +18,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/ksonnet/kubecfg/metadata"
 	"github.com/ksonnet/kubecfg/pkg/kubecfg"
@@ -36,22 +38,14 @@ func init() {
 }
 
 var diffCmd = &cobra.Command{
-	Use:   "diff [env-name] [-f <file-or-dir>]",
-	Short: "Display differences between server and local config",
+	Use:   "diff [env-name] [env-name] [-f <file-or-dir>]",
+	Short: "Display differences between server and local config, or server and server config",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 1 {
-			return fmt.Errorf("'diff' takes at most a single argument, that is the name of the environment")
+		if len(args) > 2 {
+			return fmt.Errorf("'diff' takes at most two argument, that is the name of the environments")
 		}
 
 		flags := cmd.Flags()
-		var err error
-
-		c := kubecfg.DiffCmd{}
-
-		c.DiffStrategy, err = flags.GetString(flagDiffStrategy)
-		if err != nil {
-			return err
-		}
 
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -64,31 +58,40 @@ var diffCmd = &cobra.Command{
 			return err
 		}
 
-		c.ClientPool, c.Discovery, err = restClientPool(cmd, envSpec.env)
+		diffStrategy, err := flags.GetString(flagDiffStrategy)
 		if err != nil {
 			return err
 		}
 
-		c.DefaultNamespace, err = defaultNamespace(clientConfig)
+		c, err := initDiffCmd(cmd, wd, envSpec, diffStrategy)
 		if err != nil {
 			return err
 		}
 
-		objs, err := expandEnvCmdObjs(cmd, envSpec, wd)
-		if err != nil {
-			return err
-		}
-
-		return c.Run(objs, cmd.OutOrStdout())
+		return c.Run(cmd.OutOrStdout())
 	},
-	Long: `Display differences between server and local configuration.
+	Long: `Display differences between server and local configuration, or server and server
+configurations.
 
 ksonnet applications are accepted, as well as normal JSON, YAML, and Jsonnet
 files.`,
-	Example: `  # Show diff between resources described in a local ksonnet application and
-  # the cluster referenced by the 'dev' environment. Can be used in any
-  # subdirectory of the application.
+	Example: `  # Show diff between resources described in a the local 'dev' environment
+  # specified by the ksonnet application and the remote cluster referenced by
+  # the same 'dev' environment. Can be used in any subdirectory of the application.
   ksonnet diff dev
+
+  # Show diff between resources at remote clusters. This requires ksonnet
+  # application defined environments. Diff between the cluster defined at the
+  # 'us-west/dev' environment, and the cluster defined at the 'us-west/prod'
+  # environment. Can be used in any subdirectory of the application.
+  ksonnet diff remote:us-west/dev remote:us-west/prod
+
+  # Show diff between resources at a remote and a local cluster. This requires
+  # ksonnet application defined environments. Diff between the cluster defined
+  # at the 'us-west/dev' environment, and the cluster defined at the
+  # 'us-west/prod' environment. Can be used in any subdirectory of the
+  # application.
+  ksonnet diff local:us-west/dev remote:us-west/prod
 
   # Show diff between resources described in a YAML file and the cluster
   # referenced in '$KUBECONFIG'.
@@ -101,4 +104,98 @@ files.`,
   # Show diff between resources described in a YAML file and the cluster
   # referred to by './kubeconfig'.
   ksonnet diff --kubeconfig=./kubeconfig -f ./pod.yaml`,
+}
+
+func initDiffCmd(cmd *cobra.Command, wd metadata.AbsPath, envSpec *envSpec, diffStrategy string) (kubecfg.DiffCmd, error) {
+	const (
+		remote = "remote"
+		local  = "local"
+	)
+
+	var err error
+
+	// ---------------------------------------------------------------------------
+	// Diff between expanded Kubernete objects and objects on a remote cluster
+	// ---------------------------------------------------------------------------
+	if envSpec.env2 == nil {
+		c := kubecfg.DiffRemoteCmd{}
+		c.DiffStrategy = diffStrategy
+		c.Client = &kubecfg.Client{}
+
+		c.Client.APIObjects, err = expandEnvCmdObjs(cmd, envSpec, wd)
+		if err != nil {
+			return nil, err
+		}
+
+		c.Client.ClientPool, c.Client.Discovery, err = restClientPool(cmd, envSpec.env)
+		if err != nil {
+			return nil, err
+		}
+
+		c.Client.Namespace, err = defaultNamespace(clientConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		return &c, nil
+	}
+
+	env1 := strings.SplitN(*envSpec.env, ":", 2)
+	env2 := strings.SplitN(*envSpec.env2, ":", 2)
+
+	if len(env1) < 2 || len(env2) < 2 || (env1[0] != local && env1[0] != remote) || (env2[0] != local && env2[0] != remote) {
+		return nil, fmt.Errorf("[env-name] must be prefaced by %s: or %s:, ex: %s:us-west/prod", local, remote, remote)
+	}
+
+	// ---------------------------------------------------------------------------
+	// Diff between two sets of expanded Kubernete objects
+	// ---------------------------------------------------------------------------
+	if env1[0] == local && env2[0] == local {
+		c := kubecfg.DiffLocalCmd{}
+		c.DiffStrategy = diffStrategy
+
+		manager, err := metadata.Find(wd)
+		if err != nil {
+			return nil, err
+		}
+
+		baseObj, err := constructBaseObj(manager)
+		if err != nil {
+			return nil, err
+		}
+
+		c.Env1 = &kubecfg.LocalEnv{}
+		c.Env1.Name = env1[1]
+		c.Env1.APIObjects, err = expandEnvObjs(cmd, c.Env1.Name, baseObj, manager)
+		if err != nil {
+			return nil, err
+		}
+
+		c.Env2 = &kubecfg.LocalEnv{}
+		c.Env2.Name = env2[1]
+		c.Env2.APIObjects, err = expandEnvObjs(cmd, c.Env2.Name, baseObj, manager)
+		if err != nil {
+			return nil, err
+		}
+
+		return &c, nil
+	}
+
+	return nil, nil
+}
+
+// expandEnvObjs finds and expands templates for an environment
+func expandEnvObjs(cmd *cobra.Command, env, baseObj string, manager metadata.Manager) ([]*unstructured.Unstructured, error) {
+	expander, err := newExpander(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	libPath, envLibPath, envComponentPath := manager.LibPaths(env)
+	expander.FlagJpath = append([]string{string(libPath), string(envLibPath)}, expander.FlagJpath...)
+	expander.ExtCodes = append([]string{baseObj}, expander.ExtCodes...)
+
+	envFiles := []string{string(envComponentPath)}
+
+	return expander.Expand(envFiles)
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -35,7 +35,6 @@ const flagDiffStrategy = "diff-strategy"
 
 func init() {
 	addEnvCmdFlags(diffCmd)
-	bindClientGoFlags(diffCmd)
 	bindJsonnetFlags(diffCmd)
 	diffCmd.PersistentFlags().String(flagDiffStrategy, "all", "Diff strategy, all or subset.")
 	RootCmd.AddCommand(diffCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -381,7 +381,7 @@ func expandEnvCmdObjs(cmd *cobra.Command, envSpec *envSpec, cwd metadata.AbsPath
 				return nil, err
 			}
 			baseObjExtCode := fmt.Sprintf("%s=%s", componentsExtCodeKey, constructBaseObj(fileNames))
-			expander.ExtCodes = append([]string{baseObjExtCode})
+			expander.ExtCodes = append([]string{baseObjExtCode}, expander.ExtCodes...)
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -372,16 +372,17 @@ func expandEnvCmdObjs(cmd *cobra.Command, envSpec *envSpec, cwd metadata.AbsPath
 			return nil, err
 		}
 
-		libPath, envLibPath := manager.LibPaths(*envSpec.env)
+		libPath, envLibPath, envComponentPath := manager.LibPaths(*envSpec.env)
 		expander.FlagJpath = append([]string{string(libPath), string(envLibPath)}, expander.FlagJpath...)
 
 		if !filesPresent {
-			fileNames, err = manager.ComponentPaths()
+			componentPaths, err := manager.ComponentPaths()
 			if err != nil {
 				return nil, err
 			}
-			baseObjExtCode := fmt.Sprintf("%s=%s", componentsExtCodeKey, constructBaseObj(fileNames))
+			baseObjExtCode := fmt.Sprintf("%s=%s", componentsExtCodeKey, constructBaseObj(componentPaths))
 			expander.ExtCodes = append([]string{baseObjExtCode}, expander.ExtCodes...)
+			fileNames = []string{string(envComponentPath)}
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -263,7 +263,9 @@ func restClientPool(cmd *cobra.Command, envName *string) (dynamic.ClientPool, di
 }
 
 type envSpec struct {
-	env   *string
+	env  *string
+	env2 *string
+
 	files []string
 }
 
@@ -283,12 +285,16 @@ func parseEnvCmd(cmd *cobra.Command, args []string) (*envSpec, error) {
 		return nil, err
 	}
 
-	var env *string
-	if len(args) == 1 {
-		env = &args[0]
+	var env1 *string
+	if len(args) > 0 {
+		env1 = &args[0]
+	}
+	var env2 *string
+	if len(args) > 1 {
+		env2 = &args[1]
 	}
 
-	return &envSpec{env: env, files: files}, nil
+	return &envSpec{env: env1, env2: env2, files: files}, nil
 }
 
 // overrideCluster ensures that the cluster URI specified in the environment is
@@ -380,8 +386,9 @@ func expandEnvCmdObjs(cmd *cobra.Command, envSpec *envSpec, cwd metadata.AbsPath
 			if err != nil {
 				return nil, err
 			}
-			baseObjExtCode := fmt.Sprintf("%s=%s", componentsExtCodeKey, constructBaseObj(componentPaths))
-			expander.ExtCodes = append([]string{baseObjExtCode}, expander.ExtCodes...)
+
+			baseObj := constructBaseObj(componentPaths)
+			expander.ExtCodes = append([]string{baseObj}, expander.ExtCodes...)
 			fileNames = []string{string(envComponentPath)}
 		}
 	}
@@ -412,5 +419,5 @@ func constructBaseObj(paths []string) string {
 		fmt.Fprintf(&obj, "  %s: import \"%s\",\n", name, p)
 	}
 	obj.WriteString("}\n")
-	return obj.String()
+	return fmt.Sprintf("%s=%s", componentsExtCodeKey, obj.String())
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -16,6 +16,7 @@
 package cmd
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -68,7 +69,7 @@ func TestConstructBaseObj(t *testing.T) {
 
 	for _, s := range tests {
 		res := constructBaseObj(s.inputPaths)
-		if res != s.expected {
+		if res != fmt.Sprintf("%s=%s", componentsExtCodeKey, s.expected) {
 			t.Errorf("Wrong object constructed\n  expected: %v\n  got: %v", s.expected, res)
 		}
 	}

--- a/metadata/environment.go
+++ b/metadata/environment.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	defaultEnvName = "default"
+	defaultEnvName  = "default"
+	metadataDirName = ".metadata"
 
 	schemaFilename        = "swagger.json"
 	extensionsLibFilename = "k.libsonnet"
@@ -87,11 +88,17 @@ func (m *manager) createEnvironment(name, uri string, extensionsLibData, k8sLibD
 		return err
 	}
 
+	metadataPath := appendToAbsPath(envPath, metadataDirName)
+	err = m.appFS.MkdirAll(string(metadataPath), defaultFolderPermissions)
+	if err != nil {
+		return err
+	}
+
 	log.Infof("Generating environment metadata at path '%s'", envPath)
 
 	// Generate the schema file.
 	log.Debugf("Generating '%s', length: %d", schemaFilename, len(specData))
-	schemaPath := appendToAbsPath(envPath, schemaFilename)
+	schemaPath := appendToAbsPath(metadataPath, schemaFilename)
 	err = afero.WriteFile(m.appFS, string(schemaPath), specData, defaultFilePermissions)
 	if err != nil {
 		log.Debugf("Failed to write '%s'", schemaFilename)
@@ -99,7 +106,7 @@ func (m *manager) createEnvironment(name, uri string, extensionsLibData, k8sLibD
 	}
 
 	log.Debugf("Generating '%s', length: %d", k8sLibFilename, len(k8sLibData))
-	k8sLibPath := appendToAbsPath(envPath, k8sLibFilename)
+	k8sLibPath := appendToAbsPath(metadataPath, k8sLibFilename)
 	err = afero.WriteFile(m.appFS, string(k8sLibPath), k8sLibData, defaultFilePermissions)
 	if err != nil {
 		log.Debugf("Failed to write '%s'", k8sLibFilename)
@@ -107,7 +114,7 @@ func (m *manager) createEnvironment(name, uri string, extensionsLibData, k8sLibD
 	}
 
 	log.Debugf("Generating '%s', length: %d", extensionsLibFilename, len(extensionsLibData))
-	extensionsLibPath := appendToAbsPath(envPath, extensionsLibFilename)
+	extensionsLibPath := appendToAbsPath(metadataPath, extensionsLibFilename)
 	err = afero.WriteFile(m.appFS, string(extensionsLibPath), extensionsLibData, defaultFilePermissions)
 	if err != nil {
 		log.Debugf("Failed to write '%s'", extensionsLibFilename)

--- a/metadata/environment_test.go
+++ b/metadata/environment_test.go
@@ -180,3 +180,20 @@ func TestSetEnvironment(t *testing.T) {
 		t.Fatalf("Expected set URI to be \"%s\", got:\n  %s", set.URI, envSpec.URI)
 	}
 }
+
+func TestGenerateOverrideData(t *testing.T) {
+	m := mockEnvironments(t, "test-gen-override-data")
+
+	expected := `local base = import "test-gen-override-data/environments/base.libsonnet";
+local k = import ".metadata/k.libsonnet";
+
+base + {
+  // Insert user-specified overrides here.
+}
+`
+	result := m.generateOverrideData()
+
+	if string(result) != expected {
+		t.Fatalf("Expected to generate override file with data:\n%s\n,got:\n%s", expected, result)
+	}
+}

--- a/metadata/interface.go
+++ b/metadata/interface.go
@@ -43,7 +43,7 @@ type Manager interface {
 	Root() AbsPath
 	ComponentPaths() (AbsPaths, error)
 	CreateComponent(name string, text string, templateType prototype.TemplateType) error
-	LibPaths(envName string) (libPath, envLibPath AbsPath)
+	LibPaths(envName string) (libPath, envLibPath, envComponentPath AbsPath)
 	CreateEnvironment(name, uri string, spec ClusterSpec) error
 	DeleteEnvironment(name string) error
 	GetEnvironments() ([]*Environment, error)

--- a/metadata/manager.go
+++ b/metadata/manager.go
@@ -170,7 +170,7 @@ func (m *manager) CreateComponent(name string, text string, templateType prototy
 }
 
 func (m *manager) LibPaths(envName string) (libPath, envLibPath AbsPath) {
-	return m.libPath, appendToAbsPath(m.environmentsPath, envName)
+	return m.libPath, appendToAbsPath(m.environmentsPath, envName, metadataDirName)
 }
 
 func (m *manager) createAppDirTree() error {

--- a/metadata/manager.go
+++ b/metadata/manager.go
@@ -175,8 +175,9 @@ func (m *manager) CreateComponent(name string, text string, templateType prototy
 	return afero.WriteFile(m.appFS, componentPath, []byte(text), defaultFilePermissions)
 }
 
-func (m *manager) LibPaths(envName string) (libPath, envLibPath AbsPath) {
-	return m.libPath, appendToAbsPath(m.environmentsPath, envName, metadataDirName)
+func (m *manager) LibPaths(envName string) (libPath, envLibPath, envComponentPath AbsPath) {
+	envPath := appendToAbsPath(m.environmentsPath, envName)
+	return m.libPath, appendToAbsPath(envPath, metadataDirName), appendToAbsPath(envPath, path.Base(envName)+".jsonnet")
 }
 
 func (m *manager) createAppDirTree() error {

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -17,6 +17,7 @@ package metadata
 import (
 	"fmt"
 	"os"
+	"path"
 	"sort"
 	"testing"
 
@@ -207,6 +208,21 @@ func TestComponentPaths(t *testing.T) {
 
 	if len(paths) != 2 || paths[0] != string(appFile2) || paths[1] != string(appFile1) {
 		t.Fatalf("m.ComponentPaths failed; expected '%s', got '%s'", []string{string(appFile1), string(appFile2)}, paths)
+	}
+}
+
+func TestLibPaths(t *testing.T) {
+	appName := "test-lib-paths"
+	expectedLibPath := path.Join(appName, libDir)
+	expectedEnvLibPath := path.Join(appName, environmentsDir, mockEnvName, metadataDirName)
+	m := mockEnvironments(t, appName)
+
+	libPath, envLibPath := m.LibPaths(mockEnvName)
+	if string(libPath) != expectedLibPath {
+		t.Fatalf("Expected lib path to be:\n  '%s'\n, got:\n  '%s'", expectedLibPath, libPath)
+	}
+	if string(envLibPath) != expectedEnvLibPath {
+		t.Fatalf("Expected environment lib path to be:\n  '%s'\n, got:\n  '%s'", expectedEnvLibPath, envLibPath)
 	}
 }
 

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -215,14 +215,18 @@ func TestLibPaths(t *testing.T) {
 	appName := "test-lib-paths"
 	expectedLibPath := path.Join(appName, libDir)
 	expectedEnvLibPath := path.Join(appName, environmentsDir, mockEnvName, metadataDirName)
+	expectedEnvComponentPath := path.Join(appName, environmentsDir, mockEnvName, path.Base(mockEnvName)+".jsonnet")
 	m := mockEnvironments(t, appName)
 
-	libPath, envLibPath := m.LibPaths(mockEnvName)
+	libPath, envLibPath, envComponentPath := m.LibPaths(mockEnvName)
 	if string(libPath) != expectedLibPath {
 		t.Fatalf("Expected lib path to be:\n  '%s'\n, got:\n  '%s'", expectedLibPath, libPath)
 	}
 	if string(envLibPath) != expectedEnvLibPath {
 		t.Fatalf("Expected environment lib path to be:\n  '%s'\n, got:\n  '%s'", expectedEnvLibPath, envLibPath)
+	}
+	if string(envComponentPath) != expectedEnvComponentPath {
+		t.Fatalf("Expected environment component path to be:\n  '%s'\n, got:\n  '%s'", expectedEnvComponentPath, envComponentPath)
 	}
 }
 

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -84,8 +84,10 @@ func TestInitSuccess(t *testing.T) {
 		}
 	}
 
-	envPath := appendToAbsPath(appPath, string(defaultEnvDir))
-	schemaPath := appendToAbsPath(envPath, schemaFilename)
+	envPath := appendToAbsPath(appPath, string(environmentsDir))
+	metadataPath := appendToAbsPath(appPath, string(defaultEnvDir), string(metadataDirName))
+
+	schemaPath := appendToAbsPath(metadataPath, schemaFilename)
 	bytes, err := afero.ReadFile(testFS, string(schemaPath))
 	if err != nil {
 		t.Fatalf("Failed to read swagger file at '%s':\n%v", schemaPath, err)
@@ -93,7 +95,7 @@ func TestInitSuccess(t *testing.T) {
 		t.Fatalf("Expected swagger file at '%s' to have value: '%s', got: '%s'", schemaPath, blankSwaggerData, actualSwagger)
 	}
 
-	k8sLibPath := appendToAbsPath(envPath, k8sLibFilename)
+	k8sLibPath := appendToAbsPath(metadataPath, k8sLibFilename)
 	k8sLibBytes, err := afero.ReadFile(testFS, string(k8sLibPath))
 	if err != nil {
 		t.Fatalf("Failed to read ksonnet-lib file at '%s':\n%v", k8sLibPath, err)
@@ -101,7 +103,7 @@ func TestInitSuccess(t *testing.T) {
 		t.Fatalf("Expected swagger file at '%s' to have value: '%s', got: '%s'", k8sLibPath, blankK8sLib, actualK8sLib)
 	}
 
-	extensionsLibPath := appendToAbsPath(envPath, extensionsLibFilename)
+	extensionsLibPath := appendToAbsPath(metadataPath, extensionsLibFilename)
 	extensionsLibBytes, err := afero.ReadFile(testFS, string(extensionsLibPath))
 	if err != nil {
 		t.Fatalf("Failed to read ksonnet-lib file at '%s':\n%v", extensionsLibPath, err)

--- a/metadata/manager_test.go
+++ b/metadata/manager_test.go
@@ -110,6 +110,14 @@ func TestInitSuccess(t *testing.T) {
 	} else if string(extensionsLibBytes) == "" {
 		t.Fatalf("Expected extension library file at '%s' to be non-empty", extensionsLibPath)
 	}
+
+	baseLibsonnetPath := appendToAbsPath(envPath, baseLibsonnetFile)
+	baseLibsonnetBytes, err := afero.ReadFile(testFS, string(baseLibsonnetPath))
+	if err != nil {
+		t.Fatalf("Failed to read base.libsonnet file at '%s':\n%v", baseLibsonnetPath, err)
+	} else if len(baseLibsonnetBytes) == 0 {
+		t.Fatalf("Expected base.libsonnet at '%s' to be non-empty", baseLibsonnetPath)
+	}
 }
 
 func TestFindSuccess(t *testing.T) {

--- a/pkg/kubecfg/apply.go
+++ b/pkg/kubecfg/apply.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/diff"
+	kdiff "k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -100,7 +100,7 @@ func (c ApplyCmd) Run(apiObjects []*unstructured.Unstructured, wd metadata.AbsPa
 			return fmt.Errorf("Error updating %s: %s", desc, err)
 		}
 
-		log.Debug("Updated object: ", diff.ObjectDiff(obj, newobj))
+		log.Debug("Updated object: ", kdiff.ObjectDiff(obj, newobj))
 
 		// Some objects appear under multiple kinds
 		// (eg: Deployment is both extensions/v1beta1

--- a/utils/meta.go
+++ b/utils/meta.go
@@ -95,6 +95,12 @@ func ResourceNameFor(disco discovery.ServerResourcesInterface, o runtime.Object)
 	return strings.ToLower(gvk.Kind)
 }
 
+// GroupVersionKindFor returns a lowercased kind for an Kubernete's object
+func GroupVersionKindFor(o runtime.Object) string {
+	gvk := o.GetObjectKind().GroupVersionKind()
+	return strings.ToLower(gvk.Kind)
+}
+
 // FqName returns "namespace.name"
 func FqName(o metav1.Object) string {
 	if o.GetNamespace() == "" {


### PR DESCRIPTION
First look at supporting diff between two environments.

This PR will support changes such as
`kubecfg diff local:dev local:prod`,
`kubecfg diff remote:dev remote:prod`, or
`kubecfg diff local:dev remote:dev`. 

The last is the same as the existing diff functionality `kubecfg diff dev` (which is still supported).

Note: Change is branched off #167 so commits from that PR will be listed until merged. 

Related issue: #163 