### PR TITLE
Remove unnecessary param from defaultNamespace()

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -108,7 +108,7 @@ var applyCmd = &cobra.Command{
 			return err
 		}
 
-		c.DefaultNamespace, err = defaultNamespace(clientConfig)
+		c.DefaultNamespace, err = defaultNamespace()
 		if err != nil {
 			return err
 		}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -71,7 +71,7 @@ var deleteCmd = &cobra.Command{
 			return err
 		}
 
-		c.DefaultNamespace, err = defaultNamespace(clientConfig)
+		c.DefaultNamespace, err = defaultNamespace()
 		if err != nil {
 			return err
 		}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -69,7 +69,7 @@ var diffCmd = &cobra.Command{
 			return err
 		}
 
-		c.DefaultNamespace, err = defaultNamespace(clientConfig)
+		c.DefaultNamespace, err = defaultNamespace()
 		if err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,11 +122,11 @@ var RootCmd = &cobra.Command{
 
 // clientConfig.Namespace() is broken in client-go 3.0:
 // namespace in config erroneously overrides explicit --namespace
-func defaultNamespace(c clientcmd.ClientConfig) (string, error) {
+func defaultNamespace() (string, error) {
 	if overrides.Context.Namespace != "" {
 		return overrides.Context.Namespace, nil
 	}
-	ns, _, err := c.Namespace()
+	ns, _, err := clientConfig.Namespace()
 	return ns, err
 }
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -84,7 +84,7 @@ local configuration. Accepts JSON, YAML, or Jsonnet.`,
 			return err
 		}
 
-		c.DefaultNamespace, err = defaultNamespace(clientConfig)
+		c.DefaultNamespace, err = defaultNamespace()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The `clientConfig` param currently being passed is not needed, because
it exists as a package level var in root. It also makes little sense to
pass a custom `clientConfig` because if `overrides.Context.Namespace` is
populated, the namespace that is returned is configured as an override
in the package level `clientConfig` and not the `clientConfig` in the
param.