### PR TITLE
Use server schema to improve DependencyOrder

### DIFF
--- a/pkg/kubecfg/delete.go
+++ b/pkg/kubecfg/delete.go
@@ -44,7 +44,12 @@ func (c DeleteCmd) Run(apiObjects []*unstructured.Unstructured) error {
 		return err
 	}
 
-	sort.Sort(sort.Reverse(utils.DependencyOrder(apiObjects)))
+	log.Infof("Fetching schemas for %d resources", len(apiObjects))
+	depOrder, err := utils.DependencyOrder(c.Discovery, apiObjects)
+	if err != nil {
+		return err
+	}
+	sort.Sort(sort.Reverse(depOrder))
 
 	deleteOpts := metav1.DeleteOptions{}
 	if version.Compare(1, 6) < 0 {

--- a/pkg/kubecfg/update.go
+++ b/pkg/kubecfg/update.go
@@ -56,7 +56,12 @@ func (c UpdateCmd) Run(apiObjects []*unstructured.Unstructured) error {
 		dryRunText = " (dry-run)"
 	}
 
-	sort.Sort(utils.DependencyOrder(apiObjects))
+	log.Infof("Fetching schemas for %d resources", len(apiObjects))
+	depOrder, err := utils.DependencyOrder(c.Discovery, apiObjects)
+	if err != nil {
+		return err
+	}
+	sort.Sort(depOrder)
 
 	seenUids := sets.NewString()
 

--- a/utils/client.go
+++ b/utils/client.go
@@ -172,15 +172,15 @@ func ClientForResource(pool dynamic.ClientPool, disco discovery.DiscoveryInterfa
 	return rc, nil
 }
 
-func serverResourceForGroupVersionKind(disco discovery.DiscoveryInterface, gvk schema.GroupVersionKind) (*metav1.APIResource, error) {
+func serverResourceForGroupVersionKind(disco discovery.ServerResourcesInterface, gvk schema.GroupVersionKind) (*metav1.APIResource, error) {
 	resources, err := disco.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to fetch resource description for %s: %v", gvk.GroupVersion(), err)
 	}
 
 	for _, r := range resources.APIResources {
 		if r.Kind == gvk.Kind {
-			log.Debugf("Chose API '%s' for %s", r.Name, gvk)
+			log.Debugf("Using resource '%s' for %s", r.Name, gvk)
 			return &r, nil
 		}
 	}

--- a/utils/sort.go
+++ b/utils/sort.go
@@ -16,55 +16,182 @@
 package utils
 
 import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/emicklei/go-restful-swagger12"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/discovery"
 )
 
 var (
-	gkNamespace    = schema.GroupKind{Group: "", Kind: "Namespace"}
-	gkTpr          = schema.GroupKind{Group: "extensions", Kind: "ThirdPartyResource"}
-	gkStorageClass = schema.GroupKind{Group: "storage.k8s.io", Kind: "StorageClass"}
-
-	gkPod         = schema.GroupKind{Group: "", Kind: "Pod"}
-	gkJob         = schema.GroupKind{Group: "batch", Kind: "Job"}
-	gkDeployment  = schema.GroupKind{Group: "extensions", Kind: "Deployment"}
-	gkDaemonSet   = schema.GroupKind{Group: "extensions", Kind: "DaemonSet"}
-	gkStatefulSet = schema.GroupKind{Group: "apps", Kind: "StatefulSet"}
+	gkTpr = schema.GroupKind{Group: "extensions", Kind: "ThirdPartyResource"}
+	gkCrd = schema.GroupKind{Group: "apiextensions", Kind: "CustomResourceDefinition"}
 )
 
-// These kinds all start pods.
-// TODO: expand this list.
-func isPodOrSimilar(gk schema.GroupKind) bool {
-	return gk == gkPod ||
-		gk == gkJob ||
-		gk == gkDeployment ||
-		gk == gkDaemonSet ||
-		gk == gkStatefulSet
+// Heh: Swagger. Walk. :P
+func swaggerWalk(api *swagger.ApiDeclaration, typeName string, seen sets.String, visitor func(string) error) error {
+	if !versionRegexp.MatchString(typeName) {
+		return nil
+	}
+
+	// Prevent possible schema loops
+	if seen.Has(typeName) {
+		return nil
+	}
+	seen.Insert(typeName)
+
+	if err := visitor(typeName); err != nil {
+		return err
+	}
+
+	// is an API object of some sort
+	models := api.Models
+	model, ok := models.At(typeName)
+	if !ok {
+		return fmt.Errorf("type %q not found in schema", typeName)
+	}
+
+	properties := model.Properties
+	for _, namedproperty := range properties.List {
+		details := namedproperty.Property
+		var fieldType string
+		if details.Type != nil {
+			fieldType = *details.Type
+		} else if details.Ref != nil {
+			fieldType = *details.Ref
+		} else {
+			return fmt.Errorf("type of field %q in %q undefined in schema", namedproperty.Name, typeName)
+		}
+
+		if fieldType == "array" {
+			if details.Items.Ref != nil {
+				fieldType = *details.Items.Ref
+			} else if details.Items.Type != nil {
+				fieldType = *details.Items.Type
+			} else {
+				return fmt.Errorf("array type of %q undefined in schema", fieldType)
+			}
+		}
+
+		if err := swaggerWalk(api, fieldType, seen, visitor); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+var podSpecCache = map[string]bool{}
+
+func containsPodSpec(disco discovery.SwaggerSchemaInterface, gvk schema.GroupVersionKind) bool {
+	if result, ok := podSpecCache[gvk.String()]; ok {
+		return result
+	}
+
+	swagger, err := disco.SwaggerSchema(gvk.GroupVersion())
+	if err != nil {
+		// Indeterminate result.
+		log.Debugf("Unable to fetch schema for %s (%v), assuming not a PodSpec", gvk, err)
+		return false
+	}
+
+	foundErr := errors.New("Found") // not really an error ...
+	visitor := func(typeName string) error {
+		if typeName == "v1.PodSpec" {
+			return foundErr
+		}
+		return nil
+	}
+
+	var result bool
+
+	typeName := fmt.Sprintf("%s.%s", gvk.Version, gvk.Kind)
+	err = swaggerWalk(swagger, typeName, sets.NewString(), visitor)
+	switch err {
+	case nil:
+		result = false
+	case foundErr:
+		result = true
+	default:
+		// Indeterminate result, but repeatable so may as well cache it
+		log.Debugf("Error walking swagger schema for %q: %v", typeName, err)
+		result = false
+	}
+
+	podSpecCache[gvk.String()] = result
+	return result
 }
 
 // Arbitrary numbers used to do a simple topological sort of resources.
-// TODO: expand this list.
-func depTier(o schema.ObjectKind) int {
-	gk := o.GroupVersionKind().GroupKind()
-	if gk == gkNamespace || gk == gkTpr || gk == gkStorageClass {
-		return 10
-	} else if isPodOrSimilar(gk) {
-		return 100
-	} else {
-		return 50
+func depTier(disco ServerResourcesSwaggerSchema, o schema.ObjectKind) (int, error) {
+	gvk := o.GroupVersionKind()
+	if gk := gvk.GroupKind(); gk == gkTpr || gk == gkCrd {
+		// Special case: these create other types
+		return 10, nil
 	}
+
+	rsrc, err := serverResourceForGroupVersionKind(disco, gvk)
+	if err != nil {
+		log.Debugf("unable to fetch resource for %s (%v), continuing", gvk, err)
+		return 50, nil
+	}
+
+	if !rsrc.Namespaced {
+		// Place global before namespaced
+		return 20, nil
+	} else if containsPodSpec(disco, gvk) {
+		// (Potentially) starts a pod, so place last
+		return 100, nil
+	} else {
+		// Everything else
+		return 50, nil
+	}
+}
+
+// A subset of discovery.DiscoveryInterface
+type ServerResourcesSwaggerSchema interface {
+	discovery.ServerResourcesInterface
+	discovery.SwaggerSchemaInterface
 }
 
 // DependencyOrder is a `sort.Interface` that *best-effort* sorts the
 // objects so that known dependencies appear earlier in the list.  The
 // idea is to prevent *some* of the "crash-restart" loops when
 // creating inter-dependent resources.
-type DependencyOrder []*unstructured.Unstructured
+func DependencyOrder(disco ServerResourcesSwaggerSchema, list []*unstructured.Unstructured) (sort.Interface, error) {
+	sortKeys := make([]int, len(list))
+	for i, item := range list {
+		var err error
+		sortKeys[i], err = depTier(disco, item.GetObjectKind())
+		if err != nil {
+			return nil, err
+		}
+	}
+	log.Debugf("sortKeys is %v", sortKeys)
+	return &mappedSort{sortKeys: sortKeys, items: list}, nil
+}
 
-func (l DependencyOrder) Len() int      { return len(l) }
-func (l DependencyOrder) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
-func (l DependencyOrder) Less(i, j int) bool {
-	return depTier(l[i].GetObjectKind()) < depTier(l[j].GetObjectKind())
+type mappedSort struct {
+	sortKeys []int
+	items    []*unstructured.Unstructured
+}
+
+func (l *mappedSort) Len() int { return len(l.items) }
+func (l *mappedSort) Swap(i, j int) {
+	l.sortKeys[i], l.sortKeys[j] = l.sortKeys[j], l.sortKeys[i]
+	l.items[i], l.items[j] = l.items[j], l.items[i]
+}
+func (l *mappedSort) Less(i, j int) bool {
+	if l.sortKeys[i] != l.sortKeys[j] {
+		return l.sortKeys[i] < l.sortKeys[j]
+	}
+	// Fall back to alpha sort, to give persistent order
+	return AlphabeticalOrder(l.items).Less(i, j)
 }
 
 // AlphabeticalOrder is a `sort.Interface` that sorts the

--- a/utils/sort_test.go
+++ b/utils/sort_test.go
@@ -16,16 +16,105 @@
 package utils
 
 import (
+	"fmt"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
 
+	"github.com/emicklei/go-restful-swagger12"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	ktesting "k8s.io/client-go/testing"
 )
 
-var _ sort.Interface = DependencyOrder{}
+type FakeDiscovery struct {
+	Fake     *ktesting.Fake
+	delegate discovery.SwaggerSchemaInterface
+}
+
+func NewFakeDiscovery(delegate discovery.SwaggerSchemaInterface) *FakeDiscovery {
+	fakePtr := &ktesting.Fake{}
+	return &FakeDiscovery{
+		Fake:     fakePtr,
+		delegate: delegate,
+	}
+}
+
+var _ discovery.ServerResourcesInterface = &FakeDiscovery{}
+
+func (c *FakeDiscovery) ServerResourcesForGroupVersion(gv string) (*metav1.APIResourceList, error) {
+	parsedGv, err := schema.ParseGroupVersion(gv)
+	if err != nil {
+		return nil, err
+	}
+	action := ktesting.ActionImpl{}
+	action.Verb = "get"
+	action.Resource = parsedGv.WithResource("apiresources")
+	c.Fake.Invokes(action, nil)
+
+	var rsrcs []metav1.APIResource
+	switch gv {
+	case "v1":
+		rsrcs = []metav1.APIResource{
+			{
+				Name:       "configmaps",
+				Kind:       "ConfigMap",
+				Namespaced: true,
+			},
+			{
+				Name:       "namespaces",
+				Kind:       "Namespace",
+				Namespaced: false,
+			},
+			{
+				Name:       "replicationcontrollers",
+				Kind:       "ReplicationController",
+				Namespaced: true,
+			},
+		}
+	default:
+		return nil, fmt.Errorf("gv %v not found in test implementation", gv)
+	}
+	rsrc := metav1.APIResourceList{
+		GroupVersion: gv,
+		APIResources: rsrcs,
+	}
+	return &rsrc, nil
+}
+
+func (c *FakeDiscovery) ServerResources() ([]*metav1.APIResourceList, error) {
+	panic("unimplemented")
+}
+
+func (c *FakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	panic("unimplemented")
+}
+
+func (c *FakeDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	panic("unimplemented")
+}
+
+var _ discovery.SwaggerSchemaInterface = &FakeDiscovery{}
+
+func (c *FakeDiscovery) SwaggerSchema(gv schema.GroupVersion) (*swagger.ApiDeclaration, error) {
+	log.Debugf("SwaggerSchema(%v) called", gv)
+	action := ktesting.ActionImpl{}
+	action.Verb = "get"
+	action.Resource = gv.WithResource("schema")
+	c.Fake.Invokes(action, nil)
+
+	return c.delegate.SwaggerSchema(gv)
+}
 
 func TestDepSort(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+
+	disco := NewFakeDiscovery(schemaFromFile{dir: filepath.FromSlash("../testdata")})
+
 	newObj := func(apiVersion, kind string) *unstructured.Unstructured {
 		return &unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -36,19 +125,31 @@ func TestDepSort(t *testing.T) {
 	}
 
 	objs := []*unstructured.Unstructured{
-		newObj("extensions/v1beta1", "Deployment"),
+		newObj("v1", "ReplicationController"),
 		newObj("v1", "ConfigMap"),
 		newObj("v1", "Namespace"),
-		newObj("v1", "Service"),
+		newObj("bogus/v1", "UnknownKind"),
+		newObj("apiextensions/v1beta1", "CustomResourceDefinition"),
 	}
 
-	sort.Sort(DependencyOrder(objs))
-
-	if objs[0].GetKind() != "Namespace" {
-		t.Error("Namespace should be sorted first")
+	sorter, err := DependencyOrder(disco, objs)
+	if err != nil {
+		t.Fatalf("DependencyOrder error: %v", err)
 	}
-	if objs[3].GetKind() != "Deployment" {
-		t.Error("Deployment should be sorted after other objects")
+	sort.Sort(sorter)
+
+	for i, o := range objs {
+		t.Logf("obj[%d] after sort is %v", i, o.GroupVersionKind())
+	}
+
+	if objs[0].GetKind() != "CustomResourceDefinition" {
+		t.Error("CRD should be sorted first")
+	}
+	if objs[1].GetKind() != "Namespace" {
+		t.Error("Namespace should be sorted second")
+	}
+	if objs[4].GetKind() != "ReplicationController" {
+		t.Error("RC should be sorted after other objects")
 	}
 }
 


### PR DESCRIPTION
This change uses server-provided schema information to improve the
dependency-order heuristic in several important ways:

- Special-case CRD/TPR objects and sort them first.
- Sorts all non-namespaced resources before namespaced.
- Finds all (namespaced) types that mention v1.PodSpec and sorts them
  last.

This approach is generic and covers significantly more types than the
previous logic.  The only special case is now CRD/TPRs.

The downside is that the schema fetch is slow, so this change adds an
Info message to let the user know why they are waiting.