### PR TITLE
Simplify build steps now that we don't need cgo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,23 +19,10 @@ env:
     - MINIKUBE_HOME=${HOME}
     - CHANGE_MINIKUBE_NONE_USER=true
 
-# Frequent jsonnet_cgo crashes with xcode7.3 (default)
-osx_image: xcode8.3
-
 matrix:
   include:
-    - env: TARGET=x86_64-linux-musl GO_TESTFLAGS=""
     - env: DO_INTEGRATION_TEST=1 INT_KVERS=v1.7.0
   fast_finish: true
-  allow_failures:
-    # Let us know if/when 'go test' works again on MacOS..
-    # cgo requires golang >= 1.8.1 (or other workarounds) on recent
-    # osx/xcode - see https://github.com/golang/go/issues/19734
-    # 'go test' also hangs repeatably on go-1.8.3/MacOS ?
-    - os: osx
-      go: 1.8.x
-    - os: osx
-      go: 1.9.x
 
 services:
   - docker
@@ -43,43 +30,8 @@ services:
 addons:
   apt:
     packages:
-      # Most of these are musl-cross dependencies
       - wget
-      - patch
-      - git-core
-      - gcc
-      - g++
-      - make
-      - gawk
-      - bzip2
-      - gzip
-      - xz-utils
       - ca-certificates
-      - libgmp-dev
-      - libmpfr-dev
-      - libmpc-dev
-
-before_install:
-  - set -e
-  - |
-    if [ -n "$TARGET" -a ! -d "$HOME/cross/$TARGET/bin" ]; then
-      pushd /tmp
-      git clone --depth=1 https://github.com/GregorR/musl-cross.git
-      cd musl-cross
-      echo CC_BASE_PREFIX=$HOME/cross >> ./config.sh
-      if ! ./build.sh > build.log; then
-        tail -100 build.log
-        exit 1
-      fi
-      popd
-    fi
-  - |
-    if [ -n "$TARGET" ]; then
-      PATH=$PATH:$HOME/cross/$TARGET/bin
-      export CC="$TARGET-gcc"
-      export CXX="$TARGET-g++"
-      export GO_LDFLAGS='-linkmode external -extldflags=-static'
-    fi
 
 install:
   - go build -i -ldflags "$GO_LDFLAGS" .
@@ -119,7 +71,7 @@ script:
 after_script: set +e
 
 before_deploy:
-  - echo TARGET=$TARGET OS_NAME=$TRAVIS_OS_NAME GO_VERSION=$TRAVIS_GO_VERSION
+  - echo OS_NAME=$TRAVIS_OS_NAME GO_VERSION=$TRAVIS_GO_VERSION
   - EXE_NAME=kubecfg-$(go env GOOS)-$(go env GOARCH)
   - cp kubecfg $EXE_NAME
   - strip $EXE_NAME && ./$EXE_NAME version
@@ -131,7 +83,7 @@ deploy:
     secure: "T/LpWZSgeqWBgY3mUNeej55n8TbZZM7UgrHl7pej1CE2cs6YGcfyog3peiXvCcVF9NhGsm6eTXZQeFxsuWgMbWYeqlBnMkHNPPqdNpeRFgY0TkFZXHZLexfqTo2MLgrZiJ+bZl8wZnTTXukieGeLE37ugkBJyceLyfqIaxwRlpDzKPn8XtIqOMOwMq0aeUA8wjSSpuWkuwlGWKwJtI48BNExZZ1FRpPHQdAZjX6zEPT2SuRaACZdoX+3k/Fr91H6O9TplE4q5eCpEdd3y7BGGtMm3WA70SxYIZPGzfwaALGja5BapZr9Eui6ppyPGesQ8zV+zNtOsnK5Phj3QUj8M+v4BmJbxbPyhAIWmFiDlutgwZUkXI+R+SXONy1/LTuLLNSJ9WPQsC9gL09FGQmg+X0s7VpJVWxD8FScY0DJ4/bNLgeWnzwT2YTsduDktqevMpetxJWZGVQx3EN595JJKlZGtE8PouzVm7sRQEfe3Jd0XIcPfj5AV5trEBDjgHZSnU4qa9G9RdUZfswVp+R7SEwoTwEIEyOpFAwi9Qg5wkCAZFU2+86LQOLYH0Pm38//RxSXJEF1abkEb0Y/awz6KKlGBK3z1VSXvK3LQ8r9SwF2h15rD74O1mGM8Mjbs+mJXPxKpCq+BslskRYur3F8tRx45pwr8Ly9dppZd2rrswI="
   file: $EXE_NAME
   on:
-    condition: ( $TARGET = x86_64-linux-musl || $TRAVIS_OS_NAME = osx ) && ${TRAVIS_GO_VERSION}.0 =~ ^1\.9\.
+    condition: ( x$DO_INTEGRATION_TEST = x && ${TRAVIS_GO_VERSION}.0 =~ ^1\.9\.
     tags: true
   provider: releases
   skip_cleanup: true
@@ -139,7 +91,6 @@ deploy:
 cache:
   directories:
     - $GOPATH/pkg
-    - $HOME/cross
 
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GO ?= go
 GO_FLAGS ?=
 GO_LDFLAGS ?=
 GO_TESTFLAGS ?= -race
-GO_BUILDFLAGS ?= -ldflags="-X main.version=$(VERSION) $(GO_LDFLAGS)"
+GO_BUILDFLAGS ?= -tags netgo -installsuffix netgo -ldflags="-X main.version=$(VERSION) $(GO_LDFLAGS)"
 GOFMT ?= gofmt
 # GINKGO = "go test" also works if you want to avoid ginkgo tool
 GINKGO ?= ginkgo
@@ -34,7 +34,7 @@ KUBECONFIG ?= $(HOME)/.kube/config
 all: kubecfg
 
 kubecfg:
-	$(GO) build $(GO_FLAGS) $(GO_BUILDFLAGS) .
+	CGO_ENABLED=0 $(GO) build $(GO_FLAGS) $(GO_BUILDFLAGS) .
 
 test: gotest jsonnettest
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,6 @@ To build from source:
 % go get github.com/ksonnet/kubecfg
 ```
 
-Tested against golang >=1.8 and requires a functional cgo environment
-(C++ with libstdc++).
-Note that recent OSX environments
-[require golang >=1.8.1](https://github.com/golang/go/issues/19734) to
-avoid an immediate `Killed: 9`.
-
 ## Quickstart
 
 ```console


### PR DESCRIPTION
With the move to go-jsonnet, we no longer need cgo (yay), and we can
stop building musl, etc, etc.

Also: this change requires tests to pass on osx again.  The earlier
failures were believed to be specific to (cgo,osx,travis).