### PR TITLE
Add --ignore-unknown flag to validate

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -21,19 +21,30 @@ import (
 	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
+const (
+	flagIgnoreUnknown = "ignore-unknown"
+)
+
 func init() {
 	RootCmd.AddCommand(validateCmd)
+	validateCmd.PersistentFlags().Bool(flagIgnoreUnknown, false, "Don't fail if the schema for a given resource type cannot be fetched")
 }
 
 var validateCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "Compare generated manifest against server OpenAPI spec",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		flags := cmd.Flags()
 		var err error
 
 		c := kubecfg.ValidateCmd{}
 
 		_, c.Discovery, err = restClientPool(cmd)
+		if err != nil {
+			return err
+		}
+
+		c.IgnoreUnknown, err = flags.GetBool(flagIgnoreUnknown)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubecfg/validate.go
+++ b/pkg/kubecfg/validate.go
@@ -22,7 +22,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 
@@ -40,7 +39,7 @@ func (c ValidateCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer)
 	if err != nil {
 		return err
 	}
-	groupVersions := sets.NewString(v1.ExtractGroupVersions(groupList))
+	groupVersions := sets.NewString(v1.ExtractGroupVersions(groupList)...)
 
 	hasError := false
 

--- a/pkg/kubecfg/validate.go
+++ b/pkg/kubecfg/validate.go
@@ -20,7 +20,9 @@ import (
 	"io"
 
 	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 
 	"github.com/ksonnet/kubecfg/utils"
@@ -28,19 +30,49 @@ import (
 
 // ValidateCmd represents the validate subcommand
 type ValidateCmd struct {
-	Discovery discovery.DiscoveryInterface
+	Discovery     discovery.DiscoveryInterface
+	IgnoreUnknown bool
+}
+
+// newGroupVersionChecker returns a predicate that returns true if the group version is known to the server.
+func newGroupVersionChecker(d discovery.ServerGroupsInterface) (func(schema.GroupVersion) bool, error) {
+	groupList, err := d.ServerGroups()
+	if err != nil {
+		return nil, err
+	}
+	groupVersions := v1.ExtractGroupVersions(groupList)
+
+	return func(gv schema.GroupVersion) bool {
+		for _, v := range groupVersions {
+			if v == gv.String() {
+				return true
+			}
+		}
+		return false
+	}, nil
 }
 
 func (c ValidateCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer) error {
+	isGroupVersionKnown, err := newGroupVersionChecker(c.Discovery)
+	if err != nil {
+		return err
+	}
+
 	hasError := false
 
 	for _, obj := range apiObjects {
 		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
 		log.Info("Validating ", desc)
 
+		gv := obj.GroupVersionKind().GroupVersion()
+		if c.IgnoreUnknown && !isGroupVersionKnown(gv) {
+			log.Warnf("Skipping validation of %s because schema for %s is unknown", desc, gv)
+			continue
+		}
+
 		var allErrs []error
 
-		schema, err := utils.NewSwaggerSchemaFor(c.Discovery, obj.GroupVersionKind().GroupVersion())
+		schema, err := utils.NewSwaggerSchemaFor(c.Discovery, gv)
 		if err != nil {
 			allErrs = append(allErrs, fmt.Errorf("Unable to fetch schema: %v", err))
 		} else {

--- a/pkg/kubecfg/validate.go
+++ b/pkg/kubecfg/validate.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 
 	"github.com/ksonnet/kubecfg/utils"
@@ -40,15 +41,14 @@ func newGroupVersionChecker(d discovery.ServerGroupsInterface) (func(schema.Grou
 	if err != nil {
 		return nil, err
 	}
-	groupVersions := v1.ExtractGroupVersions(groupList)
 
+	groupVersions := sets.NewString()
+	for _, gv := range v1.ExtractGroupVersions(groupList) {
+		groupVersions.Insert(gv.String())
+	}
+	
 	return func(gv schema.GroupVersion) bool {
-		for _, v := range groupVersions {
-			if v == gv.String() {
-				return true
-			}
-		}
-		return false
+		return groupVersions.Has(gv.String())
 	}, nil
 }
 


### PR DESCRIPTION
that allows kubecfg validate deal with CRDs until we implement a better
fix.

See #146