### PR TITLE
Add integration tests for garbage-collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GO_TESTFLAGS ?= -race
 GO_BUILDFLAGS ?= -tags netgo -installsuffix netgo -ldflags="-X main.version=$(VERSION) $(GO_LDFLAGS)"
 GOFMT ?= gofmt
 # GINKGO = "go test" also works if you want to avoid ginkgo tool
-GINKGO ?= ginkgo
+GINKGO ?= ginkgo -p
 
 JSONNET_FILES = lib/kubecfg_test.jsonnet examples/guestbook.jsonnet
 # TODO: Simplify this once ./... ignores ./vendor

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -26,21 +26,6 @@ const (
 	flagSkipGc = "skip-gc"
 	flagGcTag  = "gc-tag"
 	flagDryRun = "dry-run"
-
-	// AnnotationGcTag annotation that triggers
-	// garbage collection. Objects with value equal to
-	// command-line flag that are *not* in config will be deleted.
-	AnnotationGcTag = "kubecfg.ksonnet.io/garbage-collect-tag"
-
-	// AnnotationGcStrategy controls gc logic.  Current values:
-	// `auto` (default if absent) - do garbage collection
-	// `ignore` - never garbage collect this object
-	AnnotationGcStrategy = "kubecfg.ksonnet.io/garbage-collect-strategy"
-
-	// GcStrategyAuto is the default automatic gc logic
-	GcStrategyAuto = "auto"
-	// GcStrategyIgnore means this object should be ignored by garbage collection
-	GcStrategyIgnore = "ignore"
 )
 
 func init() {

--- a/integration/update_test.go
+++ b/integration/update_test.go
@@ -3,10 +3,17 @@
 package integration
 
 import (
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/pkg/api/v1"
+	restclient "k8s.io/client-go/rest"
+
+	"github.com/ksonnet/kubecfg/pkg/kubecfg"
+	"github.com/ksonnet/kubecfg/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,6 +21,28 @@ import (
 
 func cmData(cm *v1.ConfigMap) map[string]string {
 	return cm.Data
+}
+
+func restClientPool(conf *restclient.Config) (dynamic.ClientPool, discovery.DiscoveryInterface, error) {
+	disco, err := discovery.NewDiscoveryClientForConfig(conf)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	discoCache := utils.NewMemcachedDiscoveryClient(disco)
+	mapper := discovery.NewDeferredDiscoveryRESTMapper(discoCache, dynamic.VersionInterfaces)
+	pathresolver := dynamic.LegacyAPIPathResolverFunc
+
+	pool := dynamic.NewClientPool(conf, mapper, pathresolver)
+	return pool, discoCache, nil
+}
+
+func restClientPoolOrDie(conf *restclient.Config) (dynamic.ClientPool, discovery.DiscoveryInterface) {
+	p, d, err := restClientPool(conf)
+	if err != nil {
+		panic(err.Error())
+	}
+	return p, d
 }
 
 var _ = Describe("update", func() {
@@ -53,7 +82,7 @@ var _ = Describe("update", func() {
 		Context("With existing object", func() {
 			BeforeEach(func() {
 				_, err := c.ConfigMaps(ns).Create(cm)
-				Expect(err).To(Not(HaveOccurred()))
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should succeed", func() {
@@ -119,6 +148,207 @@ var _ = Describe("update", func() {
 
 			Expect(c.ConfigMaps(ns2).Get("ns2", metav1.GetOptions{})).
 				NotTo(BeNil())
+		})
+	})
+
+	Context("With garbage collection enabled", func() {
+		var preExist []*v1.ConfigMap
+		var input []*v1.ConfigMap
+		var gcTag string
+		var dryRun bool
+		var skipGc bool
+
+		BeforeEach(func() {
+			gcTag = "tag-" + ns
+			preExist = []*v1.ConfigMap{}
+			input = []*v1.ConfigMap{}
+			dryRun = false
+			skipGc = false
+		})
+
+		JustBeforeEach(func() {
+			for _, obj := range preExist {
+				_, err := c.ConfigMaps(ns).Create(obj)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			args := []string{"update", "-vv", "-n", ns}
+			if gcTag != "" {
+				args = append(args, "--gc-tag", gcTag)
+			}
+			if skipGc {
+				args = append(args, "--skip-gc")
+			}
+			if dryRun {
+				args = append(args, "--dry-run")
+			}
+
+			inputObjs := make([]runtime.Object, len(input))
+			for i := range input {
+				inputObjs[i] = input[i]
+			}
+			err := runKubecfgWith(args, inputObjs)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("With existing objects", func() {
+			BeforeEach(func() {
+				preExist = []*v1.ConfigMap{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								kubecfg.AnnotationGcTag: gcTag,
+							},
+							Name: "existing",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								kubecfg.AnnotationGcTag: gcTag,
+							},
+							Name: "existing-stale",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "existing-stale-notag",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								kubecfg.AnnotationGcTag: gcTag + "-not",
+							},
+							Name: "existing-othertag",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								kubecfg.AnnotationGcTag:      gcTag,
+								kubecfg.AnnotationGcStrategy: kubecfg.GcStrategyIgnore,
+							},
+							Name: "existing-precious",
+						},
+					},
+				}
+
+				input = []*v1.ConfigMap{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "new",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "existing",
+						},
+					},
+				}
+			})
+
+			It("should add gctag to new object", func() {
+				o, err := c.ConfigMaps(ns).Get("new", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(o.ObjectMeta.Annotations).
+					To(HaveKeyWithValue(kubecfg.AnnotationGcTag, gcTag))
+			})
+
+			It("should keep gctag on existing object", func() {
+				o, err := c.ConfigMaps(ns).Get("existing", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(o.ObjectMeta.Annotations).
+					To(HaveKeyWithValue(kubecfg.AnnotationGcTag, gcTag))
+			})
+
+			It("should delete stale object", func() {
+				_, err := c.ConfigMaps(ns).Get("existing-stale", metav1.GetOptions{})
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("should not delete tagless object", func() {
+				Expect(c.ConfigMaps(ns).Get("existing-stale-notag", metav1.GetOptions{})).
+					NotTo(BeNil())
+			})
+
+			It("should not delete object with different gc tag", func() {
+				Expect(c.ConfigMaps(ns).Get("existing-othertag", metav1.GetOptions{})).
+					NotTo(BeNil())
+			})
+
+			It("should not delete strategy=ignore object", func() {
+				Expect(c.ConfigMaps(ns).Get("existing-precious", metav1.GetOptions{})).
+					NotTo(BeNil())
+			})
+		})
+
+		Context("with dry-run", func() {
+			BeforeEach(func() {
+				dryRun = true
+				preExist = []*v1.ConfigMap{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								kubecfg.AnnotationGcTag: gcTag,
+							},
+							Name: "existing",
+						},
+					},
+				}
+				input = []*v1.ConfigMap{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "new",
+						},
+					},
+				}
+			})
+
+			It("should not delete existing object", func() {
+				Expect(c.ConfigMaps(ns).Get("existing", metav1.GetOptions{})).
+					NotTo(BeNil())
+			})
+
+			It("should not create new object", func() {
+				_, err := c.ConfigMaps(ns).Get("new", metav1.GetOptions{})
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			})
+		})
+
+		Context("with skip-gc", func() {
+			BeforeEach(func() {
+				skipGc = true
+				preExist = []*v1.ConfigMap{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								kubecfg.AnnotationGcTag: gcTag,
+							},
+							Name: "existing",
+						},
+					},
+				}
+				input = []*v1.ConfigMap{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "new",
+						},
+					},
+				}
+			})
+
+			It("should not delete existing object", func() {
+				Expect(c.ConfigMaps(ns).Get("existing", metav1.GetOptions{})).
+					NotTo(BeNil())
+			})
+
+			It("should add gctag to new object", func() {
+				o, err := c.ConfigMaps(ns).Get("new", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(o.ObjectMeta.Annotations).
+					To(HaveKeyWithValue(kubecfg.AnnotationGcTag, gcTag))
+			})
 		})
 	})
 })


### PR DESCRIPTION
Important and subtle feature - definitely deserves integration test
coverage.

Also:
- run ginkgo tests in parallel by default
- cleanup stale copy of some global constants