### PR TITLE
Improve handling of missing schema

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -21,13 +21,8 @@ import (
 	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
-const (
-	flagIgnoreUnknown = "ignore-unknown"
-)
-
 func init() {
 	RootCmd.AddCommand(validateCmd)
-	validateCmd.PersistentFlags().Bool(flagIgnoreUnknown, false, "Don't fail if the schema for a given resource type cannot be fetched")
 }
 
 var validateCmd = &cobra.Command{
@@ -35,17 +30,11 @@ var validateCmd = &cobra.Command{
 	Short: "Compare generated manifest against server OpenAPI spec",
 	Args:  cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		flags := cmd.Flags()
 		var err error
 
 		c := kubecfg.ValidateCmd{}
 
 		_, c.Discovery, err = restClientPool(cmd)
-		if err != nil {
-			return err
-		}
-
-		c.IgnoreUnknown, err = flags.GetBool(flagIgnoreUnknown)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change gets rid of the `--ignore-unknown` flag.
It skips checking the schema if the resource is known but
the schema is missing.

See #146