### PR TITLE
Improve "failed to read ~/.kube/config" error message

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -387,7 +387,7 @@ func dumpJSON(v interface{}) string {
 func restClientPool(cmd *cobra.Command) (dynamic.ClientPool, discovery.DiscoveryInterface, error) {
 	conf, err := clientConfig.ClientConfig()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("Unable to read kubectl config: %v", err)
 	}
 
 	disco, err := discovery.NewDiscoveryClientForConfig(conf)


### PR DESCRIPTION
Trivial change to add more context to the "error while reading
$KUBECONFIG" error message.

I was recently confused by the non-specificity of the error message
that occurs in this situation, and if _I'm_ confused, then I feel bad
for other users :/

Before:
```console
 % KUBECONFIG=/noexist ./kubecfg update
ERROR invalid configuration: no configuration has been provided
```

After:
```console
 % KUBECONFIG=/noexist kubecfg update
ERROR Unable to read kubectl config: invalid configuration: no configuration has been provided
```