### PR TITLE
Validate input before `update`

### DIFF
--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -86,6 +86,10 @@ func containsString(haystack []string, needle string) bool {
 }
 
 func runKubecfgWith(flags []string, input []runtime.Object) error {
+	return runKubecfgWithOutput(flags, input, GinkgoWriter)
+}
+
+func runKubecfgWithOutput(flags []string, input []runtime.Object, output io.Writer) error {
 	tmpdir, err := ioutil.TempDir("", "kubecfg-testdata")
 	if err != nil {
 		return err
@@ -115,10 +119,12 @@ func runKubecfgWith(flags []string, input []runtime.Object) error {
 
 	fmt.Fprintf(GinkgoWriter, "Running %q %q\n", *kubecfgBin, args)
 	cmd := exec.Command(*kubecfgBin, args...)
-	cmd.Stdout = GinkgoWriter
-	cmd.Stderr = GinkgoWriter
+	cmd.Stdout = output
+	cmd.Stderr = output
 
-	if err := cmd.Run(); err != nil {
+	err = cmd.Run()
+	fmt.Fprint(GinkgoWriter, output)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Validate the input objects against the server-side schema before
starting an update.  This is the exact equivalent of a previous
`kubecfg validate $input && kubecfg update $input`

In particular, this will reject unrecognised JSON keys that would
previously be silently ignored by the apiserver.  It will also catch a
few classes of error (eg: wrong value types) before starting the
update - previously these would be rejected by the server, aborting
the update midway.

I'm pretty sure everyone thought something like this was already
happening, so hopefully it's a no-op.  If it hurts anyone, there's a
new `--validate=false` flag to go back to the old behaviour.

(This PR is possible thanks to the earlier validate improvements in #199)