### PR TITLE
Honour `$http_proxy` et al in HTTP Transport

### DIFF
--- a/utils/importer.go
+++ b/utils/importer.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/elazarl/go-bindata-assetfs"
 	jsonnet "github.com/google/go-jsonnet"
@@ -58,7 +60,21 @@ A real-world example:
 	and downloaded from that location
 */
 func MakeUniversalImporter(searchUrls []*url.URL) jsonnet.Importer {
-	t := &http.Transport{}
+	// Reconstructed copy of http.DefaultTransport (to avoid
+	// modifying the default)
+	t := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
 	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
 	t.RegisterProtocol("internal", http.NewFileTransport(newInternalFS("lib")))
 


### PR DESCRIPTION
Use (a copy of) `http.DefaultTransport` instead of just a bare
`http.Transport` for HTTP/HTTPS requests.  In particular, the new
Transport honours the usual `http_proxy`, etc environment variables,
and has finite connection timeouts.