### PR TITLE
Re-add --ignore-unknown flag to validate

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -36,6 +36,7 @@ func init() {
 	updateCmd.PersistentFlags().String(flagGcTag, "", "Add this tag to updated objects, and garbage collect existing objects with this tag and not in config")
 	updateCmd.PersistentFlags().Bool(flagDryRun, false, "Perform only read-only operations")
 	updateCmd.PersistentFlags().Bool(flagValidate, true, "Validate input against server schema")
+	updateCmd.PersistentFlags().Bool(flagIgnoreUnknown, false, "Don't fail validation if the schema for a given resource type is not found")
 }
 
 var updateCmd = &cobra.Command{
@@ -91,6 +92,12 @@ var updateCmd = &cobra.Command{
 			v := kubecfg.ValidateCmd{
 				Discovery: c.Discovery,
 			}
+
+			v.IgnoreUnknown, err = flags.GetBool(flagIgnoreUnknown)
+			if err != nil {
+				return err
+			}
+
 			if err := v.Run(objs, cmd.OutOrStdout()); err != nil {
 				return err
 			}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -21,8 +21,13 @@ import (
 	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 )
 
+const (
+	flagIgnoreUnknown = "ignore-unknown"
+)
+
 func init() {
 	RootCmd.AddCommand(validateCmd)
+	validateCmd.PersistentFlags().Bool(flagIgnoreUnknown, false, "Don't fail if the schema for a given resource type is not found")
 }
 
 var validateCmd = &cobra.Command{
@@ -30,11 +35,17 @@ var validateCmd = &cobra.Command{
 	Short: "Compare generated manifest against server OpenAPI spec",
 	Args:  cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		flags := cmd.Flags()
 		var err error
 
 		c := kubecfg.ValidateCmd{}
 
 		_, c.Discovery, err = restClientPool(cmd)
+		if err != nil {
+			return err
+		}
+
+		c.IgnoreUnknown, err = flags.GetBool(flagIgnoreUnknown)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubecfg/validate.go
+++ b/pkg/kubecfg/validate.go
@@ -31,7 +31,8 @@ import (
 
 // ValidateCmd represents the validate subcommand
 type ValidateCmd struct {
-	Discovery discovery.DiscoveryInterface
+	Discovery     discovery.DiscoveryInterface
+	IgnoreUnknown bool
 }
 
 func (c ValidateCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer) error {
@@ -67,7 +68,7 @@ func (c ValidateCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer)
 
 		schema, err := utils.NewSwaggerSchemaFor(c.Discovery, gv)
 		if err != nil {
-			if errors.IsNotFound(err) && gvkExists(gvk) {
+			if errors.IsNotFound(err) && (c.IgnoreUnknown || gvkExists(gvk)) {
 				log.Infof(" No schema found for %s, skipping validation", gvk)
 				continue
 			}


### PR DESCRIPTION
Sometimes we want to validate a config that contains CRDs that don't
yet exist on the server, or for whatever reason perform only a "best
effort" validation against the server's time-shifted idea of the
schema.

There are several ways we could attempt to anticipate the future
creation of such CRDs (eg: by inspecting the set of objects we are
about to create), but there is always going to be corner case that is
not covered by such logic.

This change just re-adds a `validate --ignore-unknown`
flag (originally from #191), which allows validate to skip unknown
kinds and proceed with remaining known kinds.

See also original issue #146