### PR TITLE
Parse server GitVersion

### DIFF
--- a/pkg/kubecfg/delete.go
+++ b/pkg/kubecfg/delete.go
@@ -41,7 +41,8 @@ type DeleteCmd struct {
 func (c DeleteCmd) Run(apiObjects []*unstructured.Unstructured) error {
 	version, err := utils.FetchVersion(c.Discovery)
 	if err != nil {
-		return err
+		version = utils.GetDefaultVersion()
+		log.Warnf("Unable to parse server version. Received %v. Using default %s", err, version.String())
 	}
 
 	log.Infof("Fetching schemas for %d resources", len(apiObjects))

--- a/pkg/kubecfg/update.go
+++ b/pkg/kubecfg/update.go
@@ -117,7 +117,8 @@ func (c UpdateCmd) Run(apiObjects []*unstructured.Unstructured) error {
 	if c.GcTag != "" && !c.SkipGc {
 		version, err := utils.FetchVersion(c.Discovery)
 		if err != nil {
-			return err
+			version = utils.GetDefaultVersion()
+			log.Warnf("Unable to parse server version. Received %v. Using default %s", err, version.String())
 		}
 
 		err = walkObjects(c.ClientPool, c.Discovery, metav1.ListOptions{}, func(o runtime.Object) error {

--- a/utils/meta.go
+++ b/utils/meta.go
@@ -13,6 +13,9 @@ import (
 	"k8s.io/client-go/discovery"
 )
 
+// Format v0.0.0(-master+$Format:%h$)
+var gitVersionRe = regexp.MustCompile("v([0-9])+.([0-9])+.[0-9]+.*")
+
 // ServerVersion captures k8s major.minor version in a parsed form
 type ServerVersion struct {
 	Major int
@@ -20,9 +23,7 @@ type ServerVersion struct {
 }
 
 func parseGitVersion(gitVersion string) (ServerVersion, error) {
-	// Format v0.0.0(-master+$Format:%h$)
-	re := regexp.MustCompile("v([0-9])+.([0-9])+.[0-9]+-?.*")
-	parsedVersion := re.FindStringSubmatch(gitVersion)
+	parsedVersion := gitVersionRe.FindStringSubmatch(gitVersion)
 	if len(parsedVersion) != 3 {
 		return ServerVersion{}, fmt.Errorf("Unable to parse git version %s", gitVersion)
 	}
@@ -68,7 +69,9 @@ func FetchVersion(v discovery.ServerVersionInterface) (ret ServerVersion, err er
 	return ParseVersion(version)
 }
 
-// GetDefaultVersion returns a default server version (1.8)
+// GetDefaultVersion returns a default server version. This value will be updated
+// periodically to match a current/popular version corresponding to the age of this code
+// Current default version: 1.8
 func GetDefaultVersion() ServerVersion {
 	return ServerVersion{Major: 1, Minor: 8}
 }

--- a/utils/meta.go
+++ b/utils/meta.go
@@ -44,6 +44,11 @@ func ParseVersion(v *version.Info) (ServerVersion, error) {
 	var ret ServerVersion
 	var err error
 	ret.Major, err = strconv.Atoi(v.Major)
+	if err != nil {
+		// Try to parse using GitVersion
+		return parseGitVersion(v.GitVersion)
+	}
+
 	// trim "+" in minor version (happened on GKE)
 	v.Minor = strings.TrimSuffix(v.Minor, "+")
 	ret.Minor, err = strconv.Atoi(v.Minor)

--- a/utils/meta_test.go
+++ b/utils/meta_test.go
@@ -33,6 +33,22 @@ func TestParseVersion(t *testing.T) {
 			input:    version.Info{Major: "1", Minor: "8+"},
 			expected: ServerVersion{Major: 1, Minor: 8},
 		},
+		{
+			input:    version.Info{Major: "", Minor: "", GitVersion: "v1.8.0"},
+			expected: ServerVersion{Major: 1, Minor: 8},
+		},
+		{
+			input:    version.Info{Major: "", Minor: "", GitVersion: "v1.8.8-test.0"},
+			expected: ServerVersion{Major: 1, Minor: 8},
+		},
+		{
+			input:    version.Info{Major: "1", Minor: "8", GitVersion: "v1.9.0"},
+			expected: ServerVersion{Major: 1, Minor: 8},
+		},
+		{
+			input: version.Info{Major: "", Minor: "", GitVersion: "v1.a"},
+			error: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/utils/meta_test.go
+++ b/utils/meta_test.go
@@ -38,6 +38,14 @@ func TestParseVersion(t *testing.T) {
 			expected: ServerVersion{Major: 1, Minor: 8},
 		},
 		{
+			input:    version.Info{Major: "1", Minor: "", GitVersion: "v1.8.0"},
+			expected: ServerVersion{Major: 1, Minor: 8},
+		},
+		{
+			input:    version.Info{Major: "", Minor: "8", GitVersion: "v1.8.0"},
+			expected: ServerVersion{Major: 1, Minor: 8},
+		},
+		{
 			input:    version.Info{Major: "", Minor: "", GitVersion: "v1.8.8-test.0"},
 			expected: ServerVersion{Major: 1, Minor: 8},
 		},


### PR DESCRIPTION
Fixes #200 

In case that server version `Major` and `Minor` are not set or cannot be parsed use `GitVersion`. If all of the previous approaches fail use a default version. Using 1.8 as default version to match `client-go` current version.