### PR TITLE
Phase1 of migration annotation->label for gc-tag

### DIFF
--- a/integration/update_test.go
+++ b/integration/update_test.go
@@ -250,15 +250,33 @@ var _ = Describe("update", func() {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
+								// [gctag-migration]: Change to label-only in phase2
 								kubecfg.AnnotationGcTag: gcTag,
+							},
+							Labels: map[string]string{
+								kubecfg.LabelGcTag: gcTag,
 							},
 							Name: "existing",
 						},
 					},
 					{
+						// [gctag-migration]: Pre-migration test. Remove in phase2
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
 								kubecfg.AnnotationGcTag: gcTag,
+							},
+							// No LabelGcTag!
+							Name: "existing-premigration",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								// [gctag-migration]: Change to label-only in phase2
+								kubecfg.AnnotationGcTag: gcTag,
+							},
+							Labels: map[string]string{
+								kubecfg.LabelGcTag: gcTag,
 							},
 							Name: "existing-stale",
 						},
@@ -271,7 +289,11 @@ var _ = Describe("update", func() {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
+								// [gctag-migration]: Change to label-only in phase2
 								kubecfg.AnnotationGcTag: gcTag + "-not",
+							},
+							Labels: map[string]string{
+								kubecfg.LabelGcTag: gcTag + "-not",
 							},
 							Name: "existing-othertag",
 						},
@@ -279,8 +301,12 @@ var _ = Describe("update", func() {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
+								// [gctag-migration]: Change to label-only in phase2
 								kubecfg.AnnotationGcTag:      gcTag,
 								kubecfg.AnnotationGcStrategy: kubecfg.GcStrategyIgnore,
+							},
+							Labels: map[string]string{
+								kubecfg.LabelGcTag: gcTag,
 							},
 							Name: "existing-precious",
 						},
@@ -298,21 +324,41 @@ var _ = Describe("update", func() {
 							Name: "existing",
 						},
 					},
+					{
+						// [gctag-migration]: Pre-migration test. Remove in phase2
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "existing-premigration",
+						},
+					},
 				}
 			})
 
 			It("should add gctag to new object", func() {
 				o, err := c.ConfigMaps(ns).Get("new", metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
+				// [gctag-migration]: Remove annotation in phase2
 				Expect(o.ObjectMeta.Annotations).
 					To(HaveKeyWithValue(kubecfg.AnnotationGcTag, gcTag))
+				Expect(o.ObjectMeta.Labels).
+					To(HaveKeyWithValue(kubecfg.LabelGcTag, gcTag))
 			})
 
 			It("should keep gctag on existing object", func() {
 				o, err := c.ConfigMaps(ns).Get("existing", metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
+				// [gctag-migration]: Remove annotation in phase2
 				Expect(o.ObjectMeta.Annotations).
 					To(HaveKeyWithValue(kubecfg.AnnotationGcTag, gcTag))
+				Expect(o.ObjectMeta.Labels).
+					To(HaveKeyWithValue(kubecfg.LabelGcTag, gcTag))
+			})
+
+			// [gctag-migration]: Pre-migration test. Remove in phase2
+			It("should add gctag label to pre-migration object", func() {
+				o, err := c.ConfigMaps(ns).Get("existing-premigration", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(o.ObjectMeta.Labels).
+					To(HaveKeyWithValue(kubecfg.LabelGcTag, gcTag))
 			})
 
 			It("should delete stale object", func() {
@@ -342,8 +388,12 @@ var _ = Describe("update", func() {
 				preExist = []*v1.ConfigMap{
 					{
 						ObjectMeta: metav1.ObjectMeta{
+							// [gctag-migration]: Remove annotation in phase2
 							Annotations: map[string]string{
 								kubecfg.AnnotationGcTag: gcTag,
+							},
+							Labels: map[string]string{
+								kubecfg.LabelGcTag: gcTag,
 							},
 							Name: "existing",
 						},
@@ -375,8 +425,12 @@ var _ = Describe("update", func() {
 				preExist = []*v1.ConfigMap{
 					{
 						ObjectMeta: metav1.ObjectMeta{
+							// [gctag-migration]: Remove annotation in phase2
 							Annotations: map[string]string{
 								kubecfg.AnnotationGcTag: gcTag,
+							},
+							Labels: map[string]string{
+								kubecfg.LabelGcTag: gcTag,
 							},
 							Name: "existing",
 						},
@@ -399,8 +453,11 @@ var _ = Describe("update", func() {
 			It("should add gctag to new object", func() {
 				o, err := c.ConfigMaps(ns).Get("new", metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
+				// [gctag-migration]: Remove annotation in phase2
 				Expect(o.ObjectMeta.Annotations).
 					To(HaveKeyWithValue(kubecfg.AnnotationGcTag, gcTag))
+				Expect(o.ObjectMeta.Labels).
+					To(HaveKeyWithValue(kubecfg.LabelGcTag, gcTag))
 			})
 		})
 	})

--- a/pkg/kubecfg/update.go
+++ b/pkg/kubecfg/update.go
@@ -25,7 +25,20 @@ const (
 	// AnnotationGcTag annotation that triggers
 	// garbage collection. Objects with value equal to
 	// command-line flag that are *not* in config will be deleted.
-	AnnotationGcTag = "kubecfg.ksonnet.io/garbage-collect-tag"
+	//
+	// NB: this is in phase1 of a migration to use a label instead.
+	// At this stage, both label+migration are written, but the
+	// annotation (only) is still used to trigger GC. [gctag-migration]
+	AnnotationGcTag = LabelGcTag
+
+	// LabelGcTag label that triggers garbage collection. Objects
+	// with value equal to command-line flag that are *not* in
+	// config will be deleted.
+	//
+	// NB: this is in phase1 of a migration from an annotation.
+	// At this stage, both label+migration are written, but the
+	// annotation (only) is still used to trigger GC. [gctag-migration]
+	LabelGcTag = "kubecfg.ksonnet.io/garbage-collect-tag"
 
 	// AnnotationGcStrategy controls gc logic.  Current values:
 	// `auto` (default if absent) - do garbage collection
@@ -67,7 +80,9 @@ func (c UpdateCmd) Run(apiObjects []*unstructured.Unstructured) error {
 
 	for _, obj := range apiObjects {
 		if c.GcTag != "" {
+			// [gctag-migration]: Remove annotation in phase2
 			utils.SetMetaDataAnnotation(obj, AnnotationGcTag, c.GcTag)
+			utils.SetMetaDataLabel(obj, LabelGcTag, c.GcTag)
 		}
 
 		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
@@ -121,6 +136,7 @@ func (c UpdateCmd) Run(apiObjects []*unstructured.Unstructured) error {
 			log.Warnf("Unable to parse server version. Received %v. Using default %s", err, version.String())
 		}
 
+		// [gctag-migration]: Add LabelGcTag==c.GcTag to ListOptions.LabelSelector in phase2
 		err = walkObjects(c.ClientPool, c.Discovery, metav1.ListOptions{}, func(o runtime.Object) error {
 			meta, err := meta.Accessor(o)
 			if err != nil {
@@ -255,6 +271,7 @@ func eligibleForGc(obj metav1.Object, gcTag string) bool {
 		strategy = GcStrategyAuto
 	}
 
+	// [gctag-migration]: Check *label* == tag instead in phase2
 	return a[AnnotationGcTag] == gcTag &&
 		strategy == GcStrategyAuto
 }

--- a/pkg/kubecfg/update_test.go
+++ b/pkg/kubecfg/update_test.go
@@ -36,14 +36,25 @@ func TestEligibleForGc(t *testing.T) {
 		t.Errorf("%v should not be eligible (no tag)", o)
 	}
 
+	// [gctag-migration]: Remove annotation in phase2
 	utils.SetMetaDataAnnotation(o, AnnotationGcTag, "unknowntag")
+	utils.SetMetaDataLabel(o, LabelGcTag, "unknowntag")
 	if eligibleForGc(o, myTag) {
 		t.Errorf("%v should not be eligible (wrong tag)", o)
 	}
 
+	// [gctag-migration]: Remove annotation in phase2
 	utils.SetMetaDataAnnotation(o, AnnotationGcTag, myTag)
+	utils.SetMetaDataLabel(o, LabelGcTag, myTag)
 	if !eligibleForGc(o, myTag) {
 		t.Errorf("%v should be eligible", o)
+	}
+
+	// [gctag-migration]: Remove testcase in phase2
+	utils.SetMetaDataAnnotation(o, AnnotationGcTag, myTag)
+	delete(o.GetLabels(), LabelGcTag) // no label. ie: pre-migration
+	if !eligibleForGc(o, myTag) {
+		t.Errorf("%v should be eligible (gctag-migration phase1)", o)
 	}
 
 	utils.SetMetaDataAnnotation(o, AnnotationGcStrategy, GcStrategyIgnore)

--- a/utils/meta.go
+++ b/utils/meta.go
@@ -111,6 +111,16 @@ func SetMetaDataAnnotation(obj metav1.Object, key, value string) {
 	obj.SetAnnotations(a)
 }
 
+// SetMetaDataLabel sets an annotation value
+func SetMetaDataLabel(obj metav1.Object, key, value string) {
+	l := obj.GetLabels()
+	if l == nil {
+		l = make(map[string]string)
+	}
+	l[key] = value
+	obj.SetLabels(l)
+}
+
 // ResourceNameFor returns a lowercase plural form of a type, for
 // human messages.  Returns lowercased kind if discovery lookup fails.
 func ResourceNameFor(disco discovery.ServerResourcesInterface, o runtime.Object) string {


### PR DESCRIPTION
We want to find all objects using the garbage-collect tag.  This means
we *should* have used a label for this, so we get indexing,
server-side filtering, etc.

Migration plan annotation->label:
- phase1 (this change): write annotation+label; continue to read annotation
- release v.A
- phase2 (future change): read/write label only; remove annotation code
- release v.B

This means writers have to run v.A at least once before moving to v.B,
and can't go back from v.B.

Plan B (if that nice v.A->v.B track doesn't work out for a user) is to
run `update` with some version off one set of configs, and
then (without removing objects from configs) run `update --skip-gc`
with v.B once. Then regular `update` with v.B will work with the new
label.

Partial-fix for #205