### PR TITLE
Value for REDIS_MASTER_PORT_NUMBER must be a string literal.

### DIFF
--- a/examples/guestbook.jsonnet
+++ b/examples/guestbook.jsonnet
@@ -111,7 +111,7 @@ local redis(name) = {
                 env_+: {
                   REDIS_REPLICATION_MODE: "slave",
                   REDIS_MASTER_HOST: $.master.svc.metadata.name,
-                  REDIS_MASTER_PORT_NUMBER: 6379,
+                  REDIS_MASTER_PORT_NUMBER: "6379",
                 },
               },
             },


### PR DESCRIPTION
In "examples/guestbook.jsonnet", value for REDIS_MASTER_PORT_NUMBER must be a string literal.