### PR TITLE
Default to --ignore-unknown=true

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -27,7 +27,7 @@ const (
 
 func init() {
 	RootCmd.AddCommand(validateCmd)
-	validateCmd.PersistentFlags().Bool(flagIgnoreUnknown, false, "Don't fail if the schema for a given resource type is not found")
+	validateCmd.PersistentFlags().Bool(flagIgnoreUnknown, true, "Don't fail if the schema for a given resource type is not found")
 }
 
 var validateCmd = &cobra.Command{

--- a/integration/validate_test.go
+++ b/integration/validate_test.go
@@ -101,22 +101,22 @@ var _ = Describe("validate", func() {
 			})
 		})
 
-		It("Should fail with a useful error", func() {
-			Expect(kubecfgErr).To(HaveOccurred())
-			Expect(output).
-				To(ContainSubstring(`"/v1, Kind=xConfigMap" not found`))
-			Expect(output).
-				To(ContainSubstring("Validation failed"))
+		It("should succeed", func() {
+			Expect(kubecfgErr).NotTo(HaveOccurred())
+			Expect(output).NotTo(ContainSubstring("Validation failed"))
 		})
 
-		Context("With --ignore-unknown", func() {
+		Context("With --ignore-unknown=false", func() {
 			BeforeEach(func() {
-				args = append(args, "--ignore-unknown")
+				args = append(args, "--ignore-unknown=false")
 			})
 
-			It("should succeed", func() {
-				Expect(kubecfgErr).NotTo(HaveOccurred())
-				Expect(output).NotTo(ContainSubstring("Validation failed"))
+			It("Should fail with a useful error", func() {
+				Expect(kubecfgErr).To(HaveOccurred())
+				Expect(output).
+					To(ContainSubstring(`"/v1, Kind=xConfigMap" not found`))
+				Expect(output).
+					To(ContainSubstring("Validation failed"))
 			})
 		})
 	})
@@ -137,22 +137,22 @@ var _ = Describe("validate", func() {
 			})
 		})
 
-		It("Should fail with a useful error", func() {
-			Expect(kubecfgErr).To(HaveOccurred())
-			Expect(output).
-				To(ContainSubstring(`"example.com/v1alpha1, Kind=UnregisteredKind" not found`))
-			Expect(output).
-				To(ContainSubstring("Validation failed"))
+		It("should succeed", func() {
+			Expect(kubecfgErr).NotTo(HaveOccurred())
+			Expect(output).NotTo(ContainSubstring("Validation failed"))
 		})
 
-		Context("With --ignore-unknown", func() {
+		Context("With --ignore-unknown=false", func() {
 			BeforeEach(func() {
-				args = append(args, "--ignore-unknown")
+				args = append(args, "--ignore-unknown=false")
 			})
 
-			It("should succeed", func() {
-				Expect(kubecfgErr).NotTo(HaveOccurred())
-				Expect(output).NotTo(ContainSubstring("Validation failed"))
+			It("Should fail with a useful error", func() {
+				Expect(kubecfgErr).To(HaveOccurred())
+				Expect(output).
+					To(ContainSubstring(`"example.com/v1alpha1, Kind=UnregisteredKind" not found`))
+				Expect(output).
+					To(ContainSubstring("Validation failed"))
 			})
 		})
 	})


### PR DESCRIPTION
Invert the default for `--ignore-unknown` so that we now ignore
unknown types by default, and require `--ignore-unknown=false` to make
these fatal.  This follows the `kubectl` behaviour, and makes the
`kubecfg` default more likely to "just work" in the presence of CRDs,
etc.

Fixes #211