### PR TITLE
Rework kubecfg diff code.

### DIFF
--- a/pkg/kubecfg/diff.go
+++ b/pkg/kubecfg/diff.go
@@ -16,15 +16,17 @@
 package kubecfg
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"sort"
+	"regexp"
 
 	isatty "github.com/mattn/go-isatty"
 	log "github.com/sirupsen/logrus"
-	"github.com/yudai/gojsondiff"
-	"github.com/yudai/gojsondiff/formatter"
+	"github.com/sergi/go-diff/diffmatchpatch"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -48,6 +50,7 @@ type DiffCmd struct {
 func (c DiffCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer) error {
 	sort.Sort(utils.AlphabeticalOrder(apiObjects))
 
+	dmp := diffmatchpatch.New()
 	diffFound := false
 	for _, obj := range apiObjects {
 		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
@@ -78,19 +81,22 @@ func (c DiffCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer) err
 		if c.DiffStrategy == "subset" {
 			liveObjObject = removeMapFields(obj.Object, liveObjObject)
 		}
-		diff := gojsondiff.New().CompareObjects(liveObjObject, obj.Object)
 
-		if diff.Modified() {
+		liveObjText, _ := json.MarshalIndent(liveObjObject, "", "  ")
+		objText, _ := json.MarshalIndent(obj.Object, "", "  ")
+
+		liveObjTextLines, objTextLines, lines := dmp.DiffLinesToChars(string(liveObjText), string(objText))
+
+		diff := dmp.DiffMain(
+			string(liveObjTextLines),
+			string(objTextLines),
+			false)
+
+		diff = dmp.DiffCharsToLines(diff, lines)
+		if len(diff) > 0 {
 			diffFound = true
-			fcfg := formatter.AsciiFormatterConfig{
-				Coloring: istty(out),
-			}
-			formatter := formatter.NewAsciiFormatter(liveObjObject, fcfg)
-			text, err := formatter.Format(diff)
-			if err != nil {
-				return err
-			}
-			fmt.Fprintf(out, "%s", text)
+			text := c.formatDiff(diff, isatty.IsTerminal(os.Stdout.Fd()))
+			fmt.Fprintf(out, "%s\n", text)
 		} else {
 			fmt.Fprintf(out, "%s unchanged\n", desc)
 		}
@@ -100,6 +106,33 @@ func (c DiffCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer) err
 		return ErrDiffFound
 	}
 	return nil
+}
+
+// Formats the supplied Diff as a unified-diff-like text with infinite context and optionally colorizes it.
+func (c DiffCmd) formatDiff(diffs []diffmatchpatch.Diff, color bool) string {
+	var buff bytes.Buffer
+
+	// Matches all the line starts on a diff text, which is where we put diff markers and indent
+	lineStart := regexp.MustCompile("(^|\n)(.)")
+
+	for _, diff := range diffs {
+		text := diff.Text
+
+		switch diff.Type {
+		case diffmatchpatch.DiffInsert:
+			if color { _, _ = buff.WriteString("\x1b[32m") }
+			_, _ = buff.WriteString(lineStart.ReplaceAllString(text, "$1+ $2"))
+			if color { _, _ = buff.WriteString("\x1b[0m") }
+		case diffmatchpatch.DiffDelete:
+			if color { _, _ = buff.WriteString("\x1b[31m") }
+			_, _ = buff.WriteString(lineStart.ReplaceAllString(text, "$1- $2"))
+			if color { _, _ = buff.WriteString("\x1b[0m") }
+		case diffmatchpatch.DiffEqual:
+			_, _ = buff.WriteString(lineStart.ReplaceAllString(text, "$1  $2"))
+		}
+	}
+
+	return buff.String()
 }
 
 // See also feature request for golang reflect pkg at


### PR DESCRIPTION
The old code relied on gojsondiff library, which provides more semantic
JSON diffs. This library, however, had some long-standing issues which
have not been yet fixed, namely:

* https://github.com/yudai/gojsondiff/issues/24
* https://github.com/yudai/gojsondiff/issues/30

These sometimes resulted in diffs that were too noisy and/or showed
false information; this has been reported as

https://github.com/ksonnet/kubecfg/issues/229

This patch reworks kubecfg's diff code to first marshal JSON using
golang's encoding/json and then calculates the diff using
diffmatchpatch library, formatting the output as close to the
original as possible. Although this results in a more
syntactic-level diff, it might just do the job until gojsondiff
gets the above-mentioned bugs fixed.

Signed-off-by: Milan Plzik <milan.plzik@ceai.io>