### PR TITLE
Install tool dependencies separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
       - ca-certificates
 
 install:
-  - go get github.com/jteeuwen/go-bindata/go-bindata
+  - (cd $(mktemp -d); go mod init dummy; go get github.com/jteeuwen/go-bindata/go-bindata@6025e8de665b31fa74ab1a66f2cddd8c0abf887e)
   - |
     if [ "$DO_INTEGRATION_TEST" = 1 ]; then
       if ! which minikube; then
@@ -52,8 +52,9 @@ install:
       sudo -E $GOPATH/bin/minikube start --vm-driver=none \
         --extra-config apiserver.Authorization.Mode=RBAC \
         --kubernetes-version $INT_KVERS
-
-      go get github.com/onsi/ginkgo/ginkgo
+      export GO111MODULE=on
+      GINKGO_VERSION=$(go list -f '{{.Version}}' -m github.com/onsi/ginkgo)
+      (cd $(mktemp -d); go mod init dummy; go get github.com/onsi/ginkgo/ginkgo@$GINKGO_VERSION)
     fi
 
 script:


### PR DESCRIPTION
Otherwise running `go get` in in go1.11 will update the go.mod file
and causing our build to fail because we check for dirty working dir after generate.

This change also ensures that we pin the version of the tools we use.